### PR TITLE
feat: allow to auto-update to prereleases

### DIFF
--- a/packages/autopilot/src/main/settings.ts
+++ b/packages/autopilot/src/main/settings.ts
@@ -11,6 +11,7 @@ const saveSettings = debounce(_saveSettings, 300);
 export interface Settings {
     lastProfileId: string;
     profiles: Profile[];
+    channel: 'stable' | 'beta';
 }
 
 export interface Profile {
@@ -42,9 +43,14 @@ async function _saveSettings() {
 
 function createDefaultSettings(): Settings {
     return {
+        channel: 'stable',
         lastProfileId: 'default',
         profiles: [newProfile('default', 'Default')],
     };
+}
+
+export function getSettings() {
+    return settings;
 }
 
 export function getAllProfiles(): Profile[] {

--- a/packages/autopilot/src/main/updater.ts
+++ b/packages/autopilot/src/main/updater.ts
@@ -1,5 +1,8 @@
 import { autoUpdater } from 'electron-updater';
+import { getSettings } from './settings';
 
 export function checkForUpdates() {
+    const settings = getSettings();
+    autoUpdater.allowPrerelease = settings.channel === 'beta';
     autoUpdater.checkForUpdatesAndNotify();
 }


### PR DESCRIPTION
This PR allows manually adding `channel: 'beta'` to `settings.json` which, if everything is correct, will allow us to auto-update to prereleases (for internal QA purposes)