### PR TITLE
fix: make avatar icon circle, bump chromium version

### DIFF
--- a/packages/autopilot/src/app/views/account-menu.vue
+++ b/packages/autopilot/src/app/views/account-menu.vue
@@ -11,10 +11,10 @@
             <button v-if="!authorised"
                 class="button button--small button--yellow frameless"
                 @click="signIn">
-                Sign in
+                Sign-in
             </button>
             <span v-else
-                class="badge badge--round"
+                class="badge badge--round badge--circle"
                 @click="popupMenu"
                 @contextmenu.stop.prevent="popupMenu">
                 {{ text }}
@@ -95,10 +95,10 @@ export default {
     height: 2em;
 }
 
-.badge--signed-in {
-    text-transform: capitalize;
+.badge--circle {
+    text-transform: uppercase;
     height: 2.2em;
+    width: 2.2em;
     letter-spacing: 0;
-    padding: 0 4px;
 }
 </style>

--- a/packages/autopilot/src/app/views/first-run.vue
+++ b/packages/autopilot/src/app/views/first-run.vue
@@ -62,7 +62,7 @@ import { showOpenDialog } from '../util/helpers';
 import os from 'os';
 import { remote } from 'electron';
 
-export const CHROMIUM_VERSION = '706915';
+export const CHROMIUM_VERSION = '768968';
 const CHROMIUM_URL = 'https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html';
 
 export default {


### PR DESCRIPTION
- fix:  avatar icon circle
![image](https://user-images.githubusercontent.com/16660866/90518594-47c20480-e167-11ea-9aa9-cf184ecc9366.png)

- fix: bump new chromium version for `first-run.vue` (It struck me that how to inform the existing users to download new chromium version)