### PR TITLE
chore: refactor signup-warning, introduce bind vue options

### DIFF
--- a/packages/autopilot/src/app/components/signin-warning.vue
+++ b/packages/autopilot/src/app/components/signin-warning.vue
@@ -17,13 +17,11 @@
 </template>
 
 <script>
-import { ApiLoginController } from '~/controllers';
-
 export default {
 
-    bind: {
-        apiLogin: ApiLoginController,
-    },
+    inject: [
+        'apiLogin'
+    ],
 
     props: {
         message: { type: String, default: '' },

--- a/packages/autopilot/src/app/components/signin-warning.vue
+++ b/packages/autopilot/src/app/components/signin-warning.vue
@@ -1,39 +1,53 @@
 <template>
-    <div class="signin-warning automation-cloud">
+    <div class="signin-warning automation-cloud"
+        v-if="isShown">
 
-        <template v-if="!loggingIn">
-            <div class="box box--primary" style="display: flex; align-items: center;">
-                <i class="fas fa-exclamation-circle"></i>
-                <span>You need to be signed-in {{ message }}.</span>
-            </div>
+        <div class="box box--primary" style="display: flex; align-items: center;">
+            <i class="fas fa-exclamation-circle"></i>
+            <span>You need to be signed in {{ message }}.</span>
+        </div>
 
-            <button
-                class="button button--primary"
-                type="click"
-                @click="$emit('signin');">
-                <span>Sign-in</span>
-            </button>
-        </template>
+        <button
+            class="button button--primary"
+            type="click"
+            @click="apiLogin.startLogin()">
+            <span>Sign in</span>
+        </button>
     </div>
 </template>
 
 <script>
+import { ApiLoginController } from '~/controllers';
+
 export default {
-    props: {
-        message: { type: String, default: '' },
-        loggingIn: { type: Boolean, required: true },
+
+    bind: {
+        apiLogin: ApiLoginController,
     },
 
-    methods: {
+    props: {
+        message: { type: String, default: '' },
     },
+
+    computed: {
+        isShown() {
+            return this.app.initialized &&
+                !this.apiLogin.authorised &&
+                !this.apiLogin.loggingIn;
+        }
+    },
+
 };
 
 </script>
 
 <style scoped>
 .signin-warning {
-    margin: var(--gap);
     color: var(--color-cool--800);
     font-size: 1.2em;
+}
+
+.box {
+    margin: var(--gap) 0;
 }
 </style>

--- a/packages/autopilot/src/app/controllers/api-login.ts
+++ b/packages/autopilot/src/app/controllers/api-login.ts
@@ -183,7 +183,7 @@ export class ApiLoginController {
 
             function onTimeout() {
                 cleanup();
-                reject(new Error('Sign-in timeout, please try again'));
+                reject(new Error('Sign in timeout, please try again'));
             }
 
             function cleanup() {

--- a/packages/autopilot/src/app/controllers/api-login.ts
+++ b/packages/autopilot/src/app/controllers/api-login.ts
@@ -26,7 +26,9 @@ const AC_ACCOUNT_INFO_URL = stringConfig('AC_ACCOUNT_INFO_URL', '');
 export class ApiLoginController {
     userData: UserData;
     account: AccountInfo | null = null;
-    protected _loggingIn: boolean = false;
+
+    initialized: boolean = false;
+    loggingIn: boolean = false;
     protected currentEnv: 'production' | 'staging' = 'production';
 
     constructor(
@@ -43,7 +45,6 @@ export class ApiLoginController {
     }
 
     get authAgent() { return this.api.authAgent; }
-    get loggingIn() { return this._loggingIn; }
     get authorised() { return this.authAgent.params.accessToken && this.account; }
 
     async init() {
@@ -78,7 +79,7 @@ export class ApiLoginController {
     async onSwitchEnv() {
         // cleanup previous auth state
         this.invalidateAuthAgent();
-        this._loggingIn = true;
+        this.loggingIn = true;
         this.account = null;
         this.events.emit('acApiAuthorised', false);
         try {
@@ -88,7 +89,7 @@ export class ApiLoginController {
         } catch (error) {
             console.warn('failed to authorise user when switching env', { error });
         }
-        this._loggingIn = false;
+        this.loggingIn = false;
     }
 
     async retrieveRefreshToken() {
@@ -120,13 +121,13 @@ export class ApiLoginController {
             return;
         }
         try {
-            this._loggingIn = true;
+            this.loggingIn = true;
             await this.login(timeout);
         } catch (error) {
             alert(error.message);
             console.error(error);
         } finally {
-            this._loggingIn = false;
+            this.loggingIn = false;
         }
     }
 

--- a/packages/autopilot/src/app/entrypoint.ts
+++ b/packages/autopilot/src/app/entrypoint.ts
@@ -20,8 +20,16 @@ const localNodeModules = path.join(getAppPath(), 'node_modules');
 
 Vue.mixin({
     beforeCreate() {
+        const vm = (this as any);
         // Allow components to use `this.app` in their data declarations
-        (this as any).app = app;
+        vm.app = app;
+    },
+    created() {
+        const vm = (this as any);
+        // Allow binding controllers to instances in declaratively
+        for (const [key, value] of Object.entries(vm.$options.bind ?? {})) {
+            vm[key] = app.get(value as any);
+        }
     },
     data() {
         return {

--- a/packages/autopilot/src/app/entrypoint.ts
+++ b/packages/autopilot/src/app/entrypoint.ts
@@ -4,6 +4,7 @@ import RootView from './views/root.vue';
 import * as util from './util';
 import path from 'path';
 import { getAppPath } from './globals';
+import { createControllerProvider } from './provider';
 
 import './components';
 import './directives';
@@ -24,13 +25,7 @@ Vue.mixin({
         // Allow components to use `this.app` in their data declarations
         vm.app = app;
     },
-    created() {
-        const vm = (this as any);
-        // Allow binding controllers to instances in declaratively
-        for (const [key, value] of Object.entries(vm.$options.bind ?? {})) {
-            vm[key] = app.get(value as any);
-        }
-    },
+    provide: createControllerProvider(app),
     data() {
         return {
             app,

--- a/packages/autopilot/src/app/provider.ts
+++ b/packages/autopilot/src/app/provider.ts
@@ -1,0 +1,16 @@
+import { App } from './app';
+import * as ctl from './controllers';
+
+/**
+ * Creates Vue provider which allows injecting
+ * controllers in Vue components.
+ *
+ * See https://vuejs.org/v2/api/#provide-inject
+ */
+export function createControllerProvider(app: App) {
+    return {
+        extReg: app.get(ctl.ExtensionRegistryController),
+        extDev: app.get(ctl.ExtensionDevController),
+        apiLogin: app.get(ctl.ApiLoginController),
+    };
+}

--- a/packages/autopilot/src/app/viewports/ac-help/viewport.vue
+++ b/packages/autopilot/src/app/viewports/ac-help/viewport.vue
@@ -63,7 +63,7 @@
                     class="button button--primary"
                     type="click"
                     @click="onLinkClick('dashboard')">
-                    {{ authorised ? 'Dashboard' : 'Sign-in to your Dashboard' }}
+                    {{ authorised ? 'Dashboard' : 'Sign in to your Dashboard' }}
                 </button>
                 <button
                     v-show="!authorised"

--- a/packages/autopilot/src/app/viewports/api/viewport.vue
+++ b/packages/autopilot/src/app/viewports/api/viewport.vue
@@ -8,27 +8,27 @@
         </div>
 
         <loaded-info/>
-        <signin-warning
-            v-if="!apiLogin.authorised"
-            :message="signinMessage"
-            :loggingIn="apiLogin.loggingIn"
-            @signin="signIn" />
-        <!-- v-if="viewport.error.message === 'AuthorizationError'"-->
-        <div v-else>
+        <signin-warning message="to access Services and run automations on the Automation Cloud"/>
+        <template v-if="apiLogin.authorised">
             <service-list v-if="!this.viewport.selectedService"/>
             <template v-else>
                 <service-view v-if="!this.viewport.selectedJob"/>
             </template>
-        </div>
+        </template>
     </div>
 </template>
 
 <script>
+import { ApiLoginController } from '~/controllers';
 import ServiceList from './service-list.vue';
 import ServiceView from './service-view.vue';
 import LoadedInfo from './loaded-info.vue';
 
 export default {
+
+    bind: {
+        apiLogin: ApiLoginController,
+    },
 
     components: {
         ServiceList,
@@ -36,28 +36,9 @@ export default {
         LoadedInfo,
     },
 
-    data() {
-        return {
-            signinMessage: 'to access Services and run automations on the Automation Cloud',
-        };
-    },
-
     computed: {
         viewport() { return this.app.viewports.api; },
-        apiLogin() { return this.viewport.apiLogin; },
     },
-
-    methods: {
-        signIn() {
-            this.viewport.apiLogin.startLogin();
-        },
-    }
 
 };
 </script>
-
-<style>
-.api {
-
-}
-</style>

--- a/packages/autopilot/src/app/viewports/api/viewport.vue
+++ b/packages/autopilot/src/app/viewports/api/viewport.vue
@@ -19,16 +19,15 @@
 </template>
 
 <script>
-import { ApiLoginController } from '~/controllers';
 import ServiceList from './service-list.vue';
 import ServiceView from './service-view.vue';
 import LoadedInfo from './loaded-info.vue';
 
 export default {
 
-    bind: {
-        apiLogin: ApiLoginController,
-    },
+    inject: [
+        'apiLogin'
+    ],
 
     components: {
         ServiceList,

--- a/packages/autopilot/src/app/viewports/extensions/ext-item.vue
+++ b/packages/autopilot/src/app/viewports/extensions/ext-item.vue
@@ -10,10 +10,11 @@
         <section style="flex: 1">
             <div class="ext-title" @click="toggleExpand()">
                 {{ title }}
-                <i class="help-circle fas fa-question-circle"></i>
+                <i class="help-circle fas fa-question-circle"
+                    v-if="description"></i>
             </div>
-            <div class="ext-description" v-if="isExpanded">
-                {{ manifest.description }}
+            <div class="ext-description" v-if="isExpanded && description">
+                {{ description }}
             </div>
             <div class="ext-name">
                 {{ manifest.name }}:{{ manifest.latestVersion }}
@@ -69,6 +70,10 @@ export default {
         isExpanded() {
             return this.expandable.isExpanded(this.manifest.id);
         },
+
+        description() {
+            return this.manifest.description.trim();
+        }
 
     },
 

--- a/packages/autopilot/src/app/viewports/extensions/extensions.vue
+++ b/packages/autopilot/src/app/viewports/extensions/extensions.vue
@@ -15,8 +15,8 @@
                 v-if="extReg.installedManifests.length">
                 <div class="section__subtitle"
                     @click="expandable.toggleExpand('ext-installed')">
-                    <expand id="ext-installed"/>
                     Installed ({{ extReg.installedManifests.length }})
+                    <expand id="ext-installed"/>
                 </div>
                 <template v-if="expandable.isExpanded('ext-installed')">
                     <ext-item
@@ -75,7 +75,7 @@ export default {
 
 <style scoped>
 .section {
-    padding: 0 var(--gap);
+    margin: var(--gap);
 }
 
 .ext-search {

--- a/packages/autopilot/src/app/viewports/extensions/viewport.vue
+++ b/packages/autopilot/src/app/viewports/extensions/viewport.vue
@@ -8,21 +8,16 @@
 </template>
 
 <script>
-import {
-    ExtensionDevController,
-    ExtensionRegistryController,
-    ApiLoginController
-} from '~/controllers';
 import DevExtensions from './dev-extensions.vue';
 import Extensions from './extensions.vue';
 
 export default {
 
-    bind: {
-        apiLogin: ApiLoginController,
-        extDev: ExtensionDevController,
-        extReg: ExtensionRegistryController,
-    },
+    inject: [
+        'apiLogin',
+        'extDev',
+        'extReg',
+    ],
 
     components: {
         DevExtensions,

--- a/packages/autopilot/src/app/viewports/extensions/viewport.vue
+++ b/packages/autopilot/src/app/viewports/extensions/viewport.vue
@@ -1,16 +1,9 @@
 <template>
     <div class="extensions">
         <dev-extensions v-if="isDevEnabled"/>
-
-        <signin-warning
-            v-if="!apiLogin.authorised"
-            message="to the Automation Cloud to browse and load Extensions."
-            :loggingIn="apiLogin.loggingIn"
-            @signin="apiLogin.startLogin()" />
-
-        <template v-else>
-            <extensions/>
-        </template>
+        <signin-warning class="ext-warning"
+            message="to the Automation Cloud to browse and load Extensions"/>
+        <extensions v-if="apiLogin.authorised"/>
     </div>
 </template>
 
@@ -25,40 +18,31 @@ import Extensions from './extensions.vue';
 
 export default {
 
+    bind: {
+        apiLogin: ApiLoginController,
+        extDev: ExtensionDevController,
+        extReg: ExtensionRegistryController,
+    },
+
     components: {
         DevExtensions,
         Extensions,
     },
 
     computed: {
-
         script() {
             return this.app.project.script;
         },
-
         isDevEnabled() {
-            return this.get(ExtensionDevController).isDevEnabled();
+            return this.extDev.isDevEnabled();
         },
-
-        apiLogin() {
-            return this.get(ApiLoginController);
-        },
-
-        extRegistry() {
-            return this.get(ExtensionRegistryController);
-        },
-
     },
-
-    methods: {
-
-    }
 
 };
 </script>
 
-<style>
-.extensions {
-
+<style scoped>
+.ext-warning {
+    margin: 0 var(--gap);
 }
 </style>

--- a/packages/autopilot/src/app/views/account-menu.vue
+++ b/packages/autopilot/src/app/views/account-menu.vue
@@ -2,7 +2,7 @@
     <div class="account-menu">
         <template v-if="loggingIn">
             <button
-                class="button button--yellow"
+                class="button button--small button--yellow frameless"
                 disabled>
                 Signing in...
             </button>
@@ -11,7 +11,7 @@
             <button v-if="!authorised"
                 class="button button--small button--yellow frameless"
                 @click="signIn">
-                Sign-in
+                Sign in
             </button>
             <span v-else
                 class="badge badge--round badge--circle"
@@ -24,10 +24,13 @@
 </template>
 
 <script>
-import { ApiLoginController } from '~/controllers';
 import { menu } from '../util';
 
 export default {
+
+    inject: [
+        'apiLogin'
+    ],
 
     computed: {
 
@@ -39,16 +42,10 @@ export default {
             if (!this.apiLogin.account) {
                 return 'USER';
             }
-
             const { firstName, lastName, email } = this.apiLogin.account;
             const i1 = firstName[0] || null;
             const i2 = lastName[0] || null;
-
             return i1 && i2 ? i1 + i2 : email.substring(0, 2);
-        },
-
-        apiLogin() {
-            return this.get(ApiLoginController);
         },
 
     },

--- a/packages/autopilot/src/app/views/first-run.vue
+++ b/packages/autopilot/src/app/views/first-run.vue
@@ -186,7 +186,6 @@ export default {
 }
 
 .topbar {
-    --link-vertical-gap: 10px;
     flex: 0 0 auto;
     display: flex;
     flex-flow: row nowrap;

--- a/packages/autopilot/src/app/views/topbar.vue
+++ b/packages/autopilot/src/app/views/topbar.vue
@@ -158,10 +158,10 @@ export default {
 
 <style>
 .topbar {
-    --link-vertical-gap: 10px;
     flex: 0 0 auto;
     display: flex;
     flex-flow: row nowrap;
+    height: 40px;
 
     background: var(--color-mono--800);
     color: var(--ui-color--white);


### PR DESCRIPTION
This PR does two things:

- refactors the `signup-warning` component to make it more standalone and less configurable (basically to establish proper separation of concerns with its clients);
- adds `bind` option which I'd like to propose as a more declarative substitution to mapping controllers inside `computed` which tends to be too repetitive for no apparent reason.

With regards to jittery behaviour: I wasn't able to resolve it, because `apiLogin` turns out to be quite complicated. Generally speaking, we should pay more attention to data flows;I'm guessing this is the problem which lead to people relying on "time machine" debugging style — but the more important point is: it doesn't necessarily have to be this complicated. I'm pretty confident that with few bits of refactoring the whole service could become drastically simpler, and so is the data flow.

@kyungeunni Since you've already mentioned that you've touched the `ApiLoginController` in your branch I've decided to avoid modifying it, hence you'll still see this jitter when Autopilot loads. I also think it'd be a good opportunity for you to simplify it — but if in doubt, please ping me.