### PR TITLE
chore: refator ApiLoginController

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "**/out": true,
         "**/dist": true,
         "**/.tmp": true,
-        "**/static/build": true
+        "**/static/build": true,
+        "**/*.tsbuildinfo": true
     }
 }

--- a/packages/autopilot/package-lock.json
+++ b/packages/autopilot/package-lock.json
@@ -515,9 +515,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3554,9 +3554,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/packages/autopilot/package.json
+++ b/packages/autopilot/package.json
@@ -33,6 +33,7 @@
         "@types/node-fetch": "^2.5.7",
         "@ubio/css": "^2.1.7",
         "@ubio/protocol": "^7.0.0",
+        "ajv": "^6.12.5",
         "chokidar": "^3.3.1",
         "codemirror": "^5.49.2",
         "csv-stringify": "^5.3.3",

--- a/packages/autopilot/src/app/components/signin-warning.vue
+++ b/packages/autopilot/src/app/components/signin-warning.vue
@@ -31,7 +31,7 @@ export default {
     computed: {
         isShown() {
             return this.app.initialized &&
-                !this.apiLogin.authorised &&
+                !this.apiLogin.isAuthenticated &&
                 !this.apiLogin.loggingIn;
         }
     },

--- a/packages/autopilot/src/app/controllers/extension-registry.ts
+++ b/packages/autopilot/src/app/controllers/extension-registry.ts
@@ -1,4 +1,3 @@
-import { App } from '../app';
 import { UserData } from '../userdata';
 import { RegistryService, ExtensionManifest, Extension, ExtensionSpec, ExtensionVersion, Configuration, numberConfig } from '@automationcloud/engine';
 import { injectable, inject } from 'inversify';
@@ -27,8 +26,6 @@ export class ExtensionRegistryController {
     protected _manifestMap: Map<string, ExtensionManifest> = new Map();
 
     constructor(
-        @inject('App')
-        protected app: App,
         @inject(StorageController)
         protected storage: StorageController,
         @inject(EventBus)

--- a/packages/autopilot/src/app/controllers/roxi.ts
+++ b/packages/autopilot/src/app/controllers/roxi.ts
@@ -44,7 +44,7 @@ export class RoxiController {
     async init() {
         const proxy = this.proxy;
         proxy.clearRoutes();
-        if (this.isEnabled() && this.apiLogin.authorised) {
+        if (this.isEnabled() && this.apiLogin.isAuthenticated) {
             this.tags = await this.fetchTags();
             this.proxyConfig = await this.fetchSampleProxy(this.getSelectedTag());
             if (this.proxyConfig != null) {

--- a/packages/autopilot/src/app/entrypoint.ts
+++ b/packages/autopilot/src/app/entrypoint.ts
@@ -55,6 +55,11 @@ app.init().then(() => {
 
 // Expose globals for DevTools
 Object.defineProperties(window, {
+    AP: {
+        get() {
+            return createControllerProvider(app);
+        }
+    },
     util: { value: util },
     script: {
         get() {
@@ -70,10 +75,5 @@ Object.defineProperties(window, {
         get() {
             return app.browser.page;
         },
-    },
-    controllers: {
-        get() {
-            return createControllerProvider(app);
-        }
     }
 });

--- a/packages/autopilot/src/app/viewports/ac-help/viewport.vue
+++ b/packages/autopilot/src/app/viewports/ac-help/viewport.vue
@@ -63,10 +63,10 @@
                     class="button button--primary button--cta"
                     type="click"
                     @click="onLinkClick('dashboard')">
-                    {{ authorised ? 'Dashboard' : 'Sign in to your Dashboard' }}
+                    {{ isAuthenticated ? 'Dashboard' : 'Sign in to your Dashboard' }}
                 </button>
                 <button
-                    v-show="!authorised"
+                    v-show="!isAuthenticated"
                     class="button button--tertiary button--cta"
                     type="click"
                     @click="onLinkClick('signup')">
@@ -104,7 +104,7 @@ export default {
 
     computed: {
         apiLogin() { return this.get(ApiLoginController); },
-        authorised() { return this.apiLogin.authorised; },
+        isAuthenticated() { return this.apiLogin.isAuthenticated; },
     },
 
     methods: {

--- a/packages/autopilot/src/app/viewports/api/viewport.vue
+++ b/packages/autopilot/src/app/viewports/api/viewport.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="api">
         <div class="api__error"
-            v-if="apiLogin.authorised && viewport.error">
+            v-if="apiLogin.isAuthenticated && viewport.error">
             <error :err="viewport.error"
                 :allow-dismiss="true"
                 @dismiss="viewport.dismissError()"/>
@@ -9,7 +9,7 @@
 
         <loaded-info/>
         <signin-warning message="to access Services and run automations on the Automation Cloud"/>
-        <template v-if="apiLogin.authorised">
+        <template v-if="apiLogin.isAuthenticated">
             <service-list v-if="!this.viewport.selectedService"/>
             <template v-else>
                 <service-view v-if="!this.viewport.selectedJob"/>

--- a/packages/autopilot/src/app/viewports/extensions/viewport.vue
+++ b/packages/autopilot/src/app/viewports/extensions/viewport.vue
@@ -3,7 +3,7 @@
         <dev-extensions v-if="isDevEnabled"/>
         <signin-warning class="ext-warning"
             message="to the Automation Cloud to browse and load Extensions"/>
-        <extensions v-if="apiLogin.authorised"/>
+        <extensions v-if="apiLogin.isAuthenticated"/>
     </div>
 </template>
 

--- a/packages/autopilot/src/app/views/account-menu.vue
+++ b/packages/autopilot/src/app/views/account-menu.vue
@@ -8,9 +8,9 @@
             </button>
         </template>
         <template v-else>
-            <button v-if="!authorised"
+            <button v-if="!isAuthenticated"
                 class="button button--small button--yellow frameless"
-                @click="apiLogin.startLogin">
+                @click="apiLogin.startLogin()">
                 Sign in
             </button>
             <span v-else
@@ -33,13 +33,9 @@ export default {
     ],
 
     computed: {
-
-        authorised() { return this.apiLogin.authorised; },
-
+        isAuthenticated() { return this.apiLogin.isAuthenticated; },
         loggingIn() { return this.apiLogin.loggingIn; },
-
         text() { return this.apiLogin.userInitial; },
-
     },
 
     methods: {
@@ -66,7 +62,6 @@ export default {
                     },
                 }
             ];
-
             menu.popupMenu(menuItems);
         },
     },

--- a/packages/autopilot/src/app/views/proxy-select.vue
+++ b/packages/autopilot/src/app/views/proxy-select.vue
@@ -35,7 +35,7 @@ export default {
         },
 
         roxiBarShown() {
-            return this.roxi.isSecretConfigured() && this.apiLogin && this.apiLogin.authorised;
+            return this.roxi.isSecretConfigured() && this.apiLogin && this.apiLogin.isAuthenticated;
         },
 
         sampleSuccess() {

--- a/packages/autopilot/src/app/views/topbar.vue
+++ b/packages/autopilot/src/app/views/topbar.vue
@@ -147,7 +147,7 @@ export default {
     flex: 0 0 auto;
     display: flex;
     flex-flow: row nowrap;
-    height: 40px;
+    min-height: 40px;
 
     background: var(--color-mono--800);
     color: var(--ui-color--white);

--- a/packages/engine/src/main/extension.ts
+++ b/packages/engine/src/main/extension.ts
@@ -14,7 +14,7 @@ import Ajv from 'ajv';
 import { JsonSchema } from './schema';
 
 const globAsync = promisify(glob);
-const ajv = new Ajv();
+const ajv = new Ajv({ messages: true });
 
 export interface ExtensionSpec {
     name: string;


### PR DESCRIPTION
Prerequisite of https://ubio-automation.atlassian.net/jira/software/projects/SM/boards/4?selectedIssue=ROBO-311

I've started working on "slow start" which ultimately converges at ApiLoginController making a lot of retries, and a bunch of auth-dependent services retrying on top of it. I started from refactoring to make things a bit cleaner.

Here's a summary.

1. Most controllers that use `UserData` (i.e. persist some state on filesystem) do this via an implicit pattern: state is read inside `init` and is written with `update`. There is currently no enforcement on this pattern (mostly because this would require mixins with generics which are not natively supported), but it's a good idea to stick with it, because at any time you can make reason about how your controller's state is represented by JSON file inside your profile directory. Adding types to it (i.e. like `TokensPerEnv` in PR) makes it even more obvious. And simply searching by `update()` provides you with all places that modify the persistent state of your controller, which typically reveals data flow complexity (fewer writes === better).

2. Custom "decode" methods shouldn't be used (nit pick: it's not decoding (decoding is done by ApiRequest when `JSON.parse` is called), it's a payload validation). Validation tools should be used for validation :)

3. I've renamed things as I thought would be more reasonable (e.g. parameterless `setAccountToken` that did both fetching and assigning felt weird)

4. Important one: `isAuthorized` was relying on *very* intricate implementation details of request's auth agent. I think we shouldn't do this; instead, I've left a TODO to add authentication-related events to Request (will do in a separate PR) and then synchronise our controller state with Request auth state.

From here, I think we need the following.

1. Seems like retrying on 401 makes very little sense. We need to do a single "retry" if access/refresh tokens are set and we receive 401, but no retries if no auth is set. I'll come up with something in Request, separately.

2. I need to trace the dependencies of ApiLogin and make them subscribed to the auth events instead of relying on init order.