### PR TITLE
fix: focus on created item, not previous item

### DIFF
--- a/packages/autopilot/src/app/command.ts
+++ b/packages/autopilot/src/app/command.ts
@@ -66,6 +66,7 @@ export abstract class Command<V extends Viewport<any>> {
             this.viewport.getCommandBuffer().registerNewCommand(this);
         }
         this.app.events.emit('commandExecuted', this);
+        this.viewport.focus();
     }
 
     async executeUndo() {

--- a/packages/autopilot/src/app/ui/modal-menu.ts
+++ b/packages/autopilot/src/app/ui/modal-menu.ts
@@ -71,7 +71,6 @@ export class ModalMenuController implements Controller {
 
     hide() {
         this.reset();
-        this.app.viewports.focusActive();
     }
 
     getDisplayedItems(): ModalMenuItem[] {


### PR DESCRIPTION
Fixes https://ubio-automation.atlassian.net/browse/ROBO-328
- affected for contexts, pipes and actions.
- When adding a new item, it focused on the previous item, as `modal-menu.hide()` triggers `focus()` before the new item is added. 