### PR TITLE
fix: invalidate refresh token when 401 received

### DIFF
--- a/packages/autopilot/src/app/overrides/api-request.ts
+++ b/packages/autopilot/src/app/overrides/api-request.ts
@@ -31,10 +31,17 @@ export class AutopilotApiRequest extends ApiRequest {
 
     setup() {
         super.setup();
-        this.request.on('retry', (error, info) => {
+        this.request.onRetry = (error, info) => {
             console.debug('API request failed, retrying', info, error);
-        });
-        // this.request.on('beforeSend', info => console.debug(info.method, info.url, info.headers));
+        };
+        this.request.onError = (error, info) => {
+            if (info.status === 401) {
+                console.info('401 from API request, invalidating refresh token', info, error);
+                this.events.emit('apiAuthInvalidated');
+            }
+            throw error;
+        };
+
     }
 
 }

--- a/packages/autopilot/src/app/overrides/api-request.ts
+++ b/packages/autopilot/src/app/overrides/api-request.ts
@@ -34,12 +34,11 @@ export class AutopilotApiRequest extends ApiRequest {
         this.request.onRetry = (error, info) => {
             console.debug('API request failed, retrying', info, error);
         };
-        this.request.onError = (error, info) => {
+        this.request.onError = (_error, info) => {
             if (info.status === 401) {
-                console.info('401 from API request, invalidating refresh token', info, error);
+                console.info('API responded with 401, invalidating refresh token', { details: info });
                 this.events.emit('apiAuthInvalidated');
             }
-            throw error;
         };
 
     }

--- a/packages/engine/package-lock.json
+++ b/packages/engine/package-lock.json
@@ -5,21 +5,13 @@
   "requires": true,
   "dependencies": {
     "@automationcloud/request": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-2.1.0.tgz",
-      "integrity": "sha512-y74sspn3xjxLNgwEjDXHT8+uhyCHHFfPiFeh+jPx2NRUAv0C+88J2df6O7bCfZkC8Li+COOQLR/LXn/kyWTG2Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-3.0.4.tgz",
+      "integrity": "sha512-6xYOuOJDqMGvSjg1mgfkjlsK9Kkalk5TYtVa3ZR3bUShSx8zjdoDo8Q5DPzOzze+w4pCpaPiJuw6UumF8yMg3w==",
       "requires": {
         "@types/node-fetch": "^2.5.3",
-        "eventemitter3": "^4.0.7",
         "node-fetch": "^2.6.1",
         "oauth-1.0a": "^2.2.6"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
       }
     },
     "@types/accepts": {
@@ -1032,11 +1024,6 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
-    },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/packages/engine/package-lock.json
+++ b/packages/engine/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@automationcloud/request": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-3.0.4.tgz",
-      "integrity": "sha512-6xYOuOJDqMGvSjg1mgfkjlsK9Kkalk5TYtVa3ZR3bUShSx8zjdoDo8Q5DPzOzze+w4pCpaPiJuw6UumF8yMg3w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-3.0.5.tgz",
+      "integrity": "sha512-ngKu9goOq6H8JMM7o2NxnCMsmilyiNUd6sAWLDcLXqq63MA25C9FaKlrKECAMRv5Bbp68P/Od5zB4HOayicqBQ==",
       "requires": {
         "@types/node-fetch": "^2.5.3",
         "node-fetch": "^2.6.1",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -20,7 +20,7 @@
     ],
     "dependencies": {
         "@automationcloud/cdp": "^32.15.1",
-        "@automationcloud/request": "^3.0.4",
+        "@automationcloud/request": "^3.0.5",
         "@automationcloud/routing-proxy": "^32.15.1",
         "@types/diacritics": "^1.3.1",
         "@types/escape-html": "^1.0.0",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -20,7 +20,7 @@
     ],
     "dependencies": {
         "@automationcloud/cdp": "^32.15.1",
-        "@automationcloud/request": "^2.1.0",
+        "@automationcloud/request": "^3.0.4",
         "@automationcloud/routing-proxy": "^32.15.1",
         "@types/diacritics": "^1.3.1",
         "@types/escape-html": "^1.0.0",


### PR DESCRIPTION
ticket: https://ubio-automation.atlassian.net/browse/ROBO-342

When failed to renew accessToken with refreshToken, we should consider it as `singed out` and it should be notified to `apiLoginController` so that it can update its state/UI.

This PR is to emit `apiAuthInvalidated` events from apiRequest service when 401 response is returned.