### PR TITLE
feat: use `Proxy/getConnection` to get session for dynamic proxy

### DIFF
--- a/packages/worker/src/main/services/api.ts
+++ b/packages/worker/src/main/services/api.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { injectable, inject } from 'inversify';
-import { Execution, Checkpoint } from '../types';
+import { Execution, Checkpoint, ProxyConnection } from '../types';
 import {
     Context,
     Action,
@@ -153,8 +153,8 @@ export class ApiService {
         });
     }
 
-    async getProxyConfig(id: string): Promise<ProxyConfig> {
-        return await this.api.get(`/Proxy/get`, {
+    async getProxyConnection(id: string): Promise<ProxyConnection> {
+        return await this.api.get(`/Proxy/getConnection`, {
             query: { id },
         });
     }
@@ -235,21 +235,4 @@ function presentAction(action: Action): any {
         label: action.label,
         runtime: action.$runtime,
     } : null;
-}
-
-export interface ProxyConfig {
-    id: string;
-    ip: string | null;
-    tags: string[];
-    providerId: string | null;
-    totalBlockedCount: number;
-    refreshIp: boolean;
-    connection: {
-        hostname: string;
-        port: number;
-        authScheme: string;
-        username: string;
-        password: string;
-        dynamicIp: boolean;
-    };
 }

--- a/packages/worker/src/main/services/roxi.ts
+++ b/packages/worker/src/main/services/roxi.ts
@@ -48,7 +48,7 @@ export class RoxiService {
 
     async setupExecutionRoutes(execution: Execution) {
         const useRoxiCache = execution.options?.useRoxiCache || false;
-        const { connection } = await this.api.getProxyConfig(execution.proxyId);
+        const connection = await this.api.getProxyConnection(execution.proxyId);
         const username = encodeURIComponent(
             JSON.stringify({
                 ...connection,
@@ -63,5 +63,6 @@ export class RoxiService {
             password: this.config.get(ROXI_SECRET),
             useHttps: true,
         });
+        this.state.proxyConnection = { ...connection, password: '' };
     }
 }

--- a/packages/worker/src/main/services/runner.ts
+++ b/packages/worker/src/main/services/runner.ts
@@ -137,7 +137,6 @@ export class Runner {
         const context = playhead ? playhead.$context : null;
         const stats = {
             proxyId: this.state.getExecution().proxyId,
-            ip: this.state.getExecution().ip,
             workerVersion: this.state.workerVersion,
             sessionTotalTime: Date.now() - this.state.jobStartedAt,
             visitedOrigins: this.statsService.visitedOrigins,

--- a/packages/worker/src/main/services/state.ts
+++ b/packages/worker/src/main/services/state.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { injectable, inject } from 'inversify';
-import { Execution } from '../types';
+import { Execution, ProxyConnection } from '../types';
 import { Script, util, Configuration, stringConfig } from '@automationcloud/engine';
 import uuid from 'uuid';
 const pkg = (require as any)('../../../package.json');
@@ -35,6 +35,7 @@ export class WorkerState {
     domainId: string | null = null;
     jobStartedAt: number = 0;
     executionsProcessed: number = 0;
+    proxyConnection: ProxyConnection | null = null;
 
     constructor(
         @inject(Configuration)
@@ -89,6 +90,7 @@ export class WorkerState {
         this.jobId = null;
         this.serviceId = null;
         this.domainId = null;
+        this.proxyConnection = null;
     }
 
     getInfo(): WorkerInfo {

--- a/packages/worker/src/main/types.ts
+++ b/packages/worker/src/main/types.ts
@@ -22,7 +22,6 @@ export interface Execution {
     draft: boolean;
     domain: string;
     state: string;
-    ip: string;
     proxyId: string;
     checkpointId?: string;
     options?: {
@@ -55,4 +54,12 @@ export interface Checkpoint {
         sessionStorage: Array<[string, string]>;
         globals: GlobalValue[];
     };
+}
+
+export interface ProxyConnection {
+    hostname: string;
+    port: number;
+    authScheme: string;
+    username: string;
+    password: string;
 }

--- a/packages/worker/src/test/helpers.ts
+++ b/packages/worker/src/test/helpers.ts
@@ -45,7 +45,7 @@ export class TestHelpers {
     }
 
     async getProxyRoute(id: string) {
-        return await this.api.get(`/Proxy/getProxyConnection`, {
+        return await this.api.get(`/Proxy/getConnection`, {
             query: { id },
         });
     }

--- a/packages/worker/src/test/helpers.ts
+++ b/packages/worker/src/test/helpers.ts
@@ -45,7 +45,7 @@ export class TestHelpers {
     }
 
     async getProxyRoute(id: string) {
-        return await this.api.get(`/Proxy/get`, {
+        return await this.api.get(`/Proxy/getProxyConnection`, {
             query: { id },
         });
     }

--- a/packages/worker/src/test/server/api.ts
+++ b/packages/worker/src/test/server/api.ts
@@ -204,25 +204,22 @@ router.post('/api/private/execution-events', ctx => {
     ctx.body = {};
 });
 
-router.get('/api/Proxy/get', ctx => {
+router.get('/api/Proxy/getConnection', ctx => {
     const { id } = ctx.query;
-    const proxy: any = {
-        id,
-        connection: {
-            hostname: 'someOtherRoxiHostName',
-            port: 6745,
-            authScheme: 'basic',
-            username: 'testUsername',
-            password: 'pa$$word',
-        },
+    const connection: any = {
+        hostname: 'someOtherRoxiHostName',
+        port: 6745,
+        authScheme: 'basic',
+        username: 'testUsername',
+        password: 'pa$$word',
     };
     if (id === 'basicUsernameNull') {
-        proxy.connection.username = null;
+        connection.username = null;
     }
     if (id === 'basicPasswordNull') {
-        proxy.connection.password = null;
+        connection.password = null;
     }
-    ctx.body = proxy;
+    ctx.body = connection;
 });
 
 router.post('/api/private/screenshots', ctx => {

--- a/packages/worker/src/test/specs/proxy.test.ts
+++ b/packages/worker/src/test/specs/proxy.test.ts
@@ -40,11 +40,11 @@ describe('Proxy', () => {
         const [proxyRoute] = proxy.getSerializedRoutes();
         assert.ok(proxyRoute.upstream);
         const decoded = JSON.parse(decodeURIComponent(proxyRoute.upstream?.username || ''));
-        assert.equal(decoded.hostname, route.connection.hostname);
-        assert.equal(decoded.port, route.connection.port);
-        assert.equal(decoded.username, route.connection.username);
-        assert.equal(decoded.password, route.connection.password);
-        assert.equal(decoded.authScheme, route.connection.authScheme);
+        assert.equal(decoded.hostname, route.hostname);
+        assert.equal(decoded.port, route.port);
+        assert.equal(decoded.username, route.username);
+        assert.equal(decoded.password, route.password);
+        assert.equal(decoded.authScheme, route.authScheme);
         assert.equal(decoded.cache, true);
         assert.equal(decoded.partition, 'happy');
     });


### PR DESCRIPTION
Use a new endpoint that returns session applied connection
ticket: https://ubio-automation.atlassian.net/browse/ROBO-308