### PR TITLE
feat: use chrome address env in worker

### DIFF
--- a/packages/engine/src/main/services/browser.ts
+++ b/packages/engine/src/main/services/browser.ts
@@ -73,6 +73,10 @@ export class BrowserService extends Browser {
         return this._config.get(CHROME_PORT);
     }
 
+    getChromeAddress() {
+        return this._config.get(CHROME_ADDRESS);
+    }
+
     async attach(targetId: string): Promise<void> {
         this.detach();
         this._currentPage = await this.getPageForTarget(targetId);

--- a/packages/worker/src/main/services/chrome.ts
+++ b/packages/worker/src/main/services/chrome.ts
@@ -53,6 +53,7 @@ export class ChromeLaunchService {
         this.config = config;
         this.launcher = new ChromeLauncher({
             chromePort: browser.getChromePort(),
+            chromeAddress: browser.getChromeAddress(),
             chromePath: this.getPath(),
             userDataDir: this.getUserDir(),
             additionalArgs: [


### PR DESCRIPTION
Worker to use chrome address env when initiating the ChromeLauncher so that we can change the debugging address as desired