### PR TITLE
fix: flaky DOM.iframe test

### DIFF
--- a/packages/cdp/src/main/frame.ts
+++ b/packages/cdp/src/main/frame.ts
@@ -104,7 +104,7 @@ export class Frame extends EventEmitter {
         if (eventsHappened) {
             return;
         }
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             const noun = this.isMainFrame() ? 'Page' : 'Frame';
             const cleanup = () => {
                 clearTimeout(timer!);
@@ -195,20 +195,21 @@ export class Frame extends EventEmitter {
 
     async document(): Promise<RemoteElement> {
         if (!this._documentPromise) {
-            this._documentPromise = (this.evaluateElement(() => document) as Promise<RemoteElement>).catch(err => {
-                throw new Exception({
-                    name: 'PageLoadingFailed',
-                    message: 'Failed to obtain top frame document',
-                    retry: true,
-                    details: {
-                        cause: {
-                            message: err.message,
-                            code: err.code,
-                            details: err.details,
+            this._documentPromise = (this.evaluateElement(() => document) as Promise<RemoteElement>)
+                .catch(err => {
+                    throw new Exception({
+                        name: 'PageLoadingFailed',
+                        message: 'Failed to obtain top frame document',
+                        retry: true,
+                        details: {
+                            cause: {
+                                message: err.message,
+                                code: err.code,
+                                details: err.details,
+                            },
                         },
-                    },
+                    });
                 });
-            });
         }
         return await this._documentPromise;
     }

--- a/packages/engine/src/test/specs/pipes/DOM.iframe.test.ts
+++ b/packages/engine/src/test/specs/pipes/DOM.iframe.test.ts
@@ -16,8 +16,11 @@ import { runtime } from'../../runtime';
 import assert from 'assert';
 
 describe('Pipes: dom/iframe', () => {
+
     it('returns iframe document', async () => {
         await runtime.goto('/iframes/top.html');
+        // Note: we run the pipeline without retry, so let's wait for the page to load
+        await runtime.page.waitForLoad();
         const results = await runtime.runPipes([
             {
                 type: 'DOM.queryOne',


### PR DESCRIPTION
I've looked briefly at the flaky dom/iframe test, and from the looks of it the recurring error appears to be genuine, i.e. it should indeed fail — but it's not easy to make it fail reliably to reproduce.

Explanation:

- the test navigates to the page with iframes hierarchy; standard `navigate` waits for `ready` event — which does **not** guarantee that all the frames load
- after that we immediately call `runtime.runPipeline`; unlike actions which invoke pipelines with retry, this one does not retry — so it fails immediately if the document isn't ready (which _should_ be the case if our execution environment is faster than Chrome's)

So I'm convinced it's the test that needs to be fixed, and not the code.