### PR TITLE
chore: refactor routing proxy bootstrapping

### DIFF
--- a/packages/engine/src/main/services/proxy.ts
+++ b/packages/engine/src/main/services/proxy.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ProxyUpstream, RoutingProxy } from '@automationcloud/uniproxy';
+import { RoutingProxy } from '@automationcloud/uniproxy';
 import { injectable, inject } from 'inversify';
 import { Configuration, numberConfig, Logger, stringConfig } from '@automationcloud/cdp';
 import { SessionHandler } from '../session';
@@ -72,15 +72,6 @@ export class ProxyService extends RoutingProxy {
             }
             throw err;
         }
-    }
-
-    getDefaultUpstream(): ProxyUpstream | null {
-        const defaultRoute = this.getRoutes().find(_ => _.label === 'default');
-        return defaultRoute?.upstream ?? null;
-    }
-
-    setDefaultUpstream(upstream: ProxyUpstream) {
-        this.addRoute(/.*/, upstream, 'default');
     }
 
     /**

--- a/packages/worker/src/main/services/state.ts
+++ b/packages/worker/src/main/services/state.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import { injectable, inject } from 'inversify';
-import { Execution, ProxyConnection } from '../types';
-import { Script, util, Configuration, stringConfig } from '@automationcloud/engine';
+import { Execution } from '../types';
+import { Script, util, Configuration, stringConfig, uniproxy } from '@automationcloud/engine';
 import uuid from 'uuid';
 const pkg = (require as any)('../../../package.json');
 
@@ -35,7 +35,7 @@ export class WorkerState {
     domainId: string | null = null;
     jobStartedAt: number = 0;
     executionsProcessed: number = 0;
-    proxyConnection: ProxyConnection | null = null;
+    proxyUpstream: uniproxy.ProxyUpstream | null = null;
 
     constructor(
         @inject(Configuration)
@@ -90,7 +90,7 @@ export class WorkerState {
         this.jobId = null;
         this.serviceId = null;
         this.domainId = null;
-        this.proxyConnection = null;
+        this.proxyUpstream = null;
     }
 
     getInfo(): WorkerInfo {

--- a/packages/worker/src/test/specs/proxy.test.ts
+++ b/packages/worker/src/test/specs/proxy.test.ts
@@ -37,11 +37,10 @@ describe('Proxy', () => {
     it('sets default proxy route', async () => {
         const route = await runtime.helpers.getProxyRoute('someRoxiIpAddressId');
         const proxy = runtime.app.container.get(ProxyService);
-        const [proxyRoute] = proxy.getRoutes();
-        assert.ok(proxyRoute.upstream);
-        assert.strictEqual(proxyRoute.upstream?.host, route.hostname + ':' + route.port);
-        assert.strictEqual(proxyRoute.upstream?.username, route.username);
-        assert.strictEqual(proxyRoute.upstream?.password, route.password);
+        assert.ok(proxy.defaultUpstream);
+        assert.strictEqual(proxy.defaultUpstream?.host, route.hostname + ':' + route.port);
+        assert.strictEqual(proxy.defaultUpstream?.username, route.username);
+        assert.strictEqual(proxy.defaultUpstream?.password, route.password);
     });
 
     it.skip('(legacy) sets roxi route', async () => {


### PR DESCRIPTION
This simplifies the part where we obtain the default upstream, and also makes it possible for the code to remove `roxi` routing by label.

Should be a non-breaking change, but if it is, then staging CSI will scream.