### PR TITLE
chore: cleanup temporary css

### DIFF
--- a/packages/autopilot/src/app/modals/create-pipe-recipe.vue
+++ b/packages/autopilot/src/app/modals/create-pipe-recipe.vue
@@ -45,17 +45,17 @@
                 </div>
             </div>
 
-            <div class="modal__buttons">
-                <button class="button button--outlined-primary"
-                    @click="$emit('hide')">
-                    Cancel
-                </button>
-                <button class="button button--primary"
-                    @click="createRecipe()"
-                    :disabled="!canCreateRecipe">
-                    Create recipe
-                </button>
-            </div>
+        </div>
+        <div class="modal__buttons group group--gap">
+            <button class="button button--tertiary"
+                @click="$emit('hide')">
+                Cancel
+            </button>
+            <button class="button button--primary"
+                @click="createRecipe()"
+                :disabled="!canCreateRecipe">
+                Create recipe
+            </button>
         </div>
     </div>
 </template>

--- a/packages/autopilot/src/app/modals/edit-action-notes.vue
+++ b/packages/autopilot/src/app/modals/edit-action-notes.vue
@@ -11,13 +11,13 @@
                     v-focus>
                 </textarea>
             </div>
+        </div>
 
-            <div class="modal__buttons">
-                <button class="button button--primary"
-                    @click="$emit('hide')">
-                    Done
-                </button>
-            </div>
+        <div class="modal__buttons">
+            <button class="button button--primary"
+                @click="$emit('hide')">
+                Done
+            </button>
         </div>
     </div>
 </template>

--- a/packages/autopilot/src/app/modals/edit-bundle.vue
+++ b/packages/autopilot/src/app/modals/edit-bundle.vue
@@ -18,12 +18,12 @@
                         v-model="bundleProxy.excluded"/>
                 </div>
             </div>
-            <div class="modal__buttons">
-                <button class="button button--primary"
-                    @click="$emit('hide')">
-                    Done
-                </button>
-            </div>
+        </div>
+        <div class="modal__buttons">
+            <button class="button button--primary"
+                @click="$emit('hide')">
+                Done
+            </button>
         </div>
     </div>
 </template>

--- a/packages/autopilot/src/app/modals/edit-pipe-notes.vue
+++ b/packages/autopilot/src/app/modals/edit-pipe-notes.vue
@@ -1,10 +1,8 @@
 <template>
     <div class="modal">
-
         <div class="modal__header">
             Edit pipe notes
         </div>
-
         <div class="modal__body">
             <div class="form-row">
                 <div class="form-row__label">
@@ -16,21 +14,18 @@
                         v-focus/>
                 </div>
             </div>
-
             <div class="form-block">
                 <textarea
                     rows="12"
                     v-model.trim="pipeProxy.notes"></textarea>
             </div>
-
-            <div class="modal__button">
-                <button class="button button--primary"
-                    @click="$emit('hide')">
-                    Done
-                </button>
-            </div>
         </div>
-
+        <div class="modal__buttons">
+            <button class="button button--primary"
+                @click="$emit('hide')">
+                Done
+            </button>
+        </div>
     </div>
 </template>
 

--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -1,9 +1,13 @@
 <template>
     <div class="modal">
-        <div class="modal__header font-family--alt"> Open </div>
+        <div class="modal__header">
+            Open
+        </div>
         <div class="modal__body">
             <div>
-                <div class="location-header">Location</div>
+                <div class="section__title">
+                    Location
+                    </div>
                 <div class="form-row">
                     <div class="form-row__controls">
                         <input class="input"
@@ -35,10 +39,9 @@
             <div v-if="location === 'ac'">
                 <signin-warning message="to open automation from the Automation Cloud" />
                 <div v-if="isAuthenticated">
-                    <div
-                        class="box font-family--alt"
-                        style="background: var(--color-cool--200);">
-                        Signed-in as {{ userName }} </div>
+                    <div class="signed-in-box">
+                        Signed-in as {{ userName }}
+                    </div>
                     <div class="form-row">
                         <div class="form-row__label">
                             Automation
@@ -85,7 +88,7 @@
                 </div>
             </div>
         </div>
-        <div class="actions automation-cloud">
+        <div class="modal__buttons automation-cloud">
             <button class="button button--tertiary"
                 @click="$emit('hide')">
                 Cancel
@@ -232,21 +235,10 @@ export default {
 </script>
 
 <style scoped>
-.location-header {
-    font-family: var(--font-family--alt);
-    font-size: 1.6em;
-    margin-bottom: var(--gap--large);
-}
-
-.actions {
-    background: var(--color-cool--100);
-    padding: var(--gap) 0;
-    display: flex;
-    justify-content: flex-end;
-}
-
-.actions .button {
-    font-weight: 500;
-    font-size: 1.4em;
+/* TODO extract */
+.signed-in-box {
+    padding: var(--gap--large);
+    background: var(--color-cool--200);
+    border-radius: var(--border-radius);
 }
 </style>

--- a/packages/autopilot/src/app/modals/save-automation.vue
+++ b/packages/autopilot/src/app/modals/save-automation.vue
@@ -1,11 +1,11 @@
 <template>
     <div class="modal">
-        <div class="modal__header font-family--alt">
+        <div class="modal__header">
             Save As
         </div>
         <div class="modal__body">
-            <div>
-                <div class="location-header">Location</div>
+            <div class="section">
+                <div class="section__title">Location</div>
                 <div class="form-row">
                     <div class="form-row__controls">
                         <input class="input"
@@ -37,10 +37,9 @@
             <div v-if="location === 'ac'">
                 <signin-warning message="to save and run automations in the Automation Cloud" />
                 <div v-if="isAuthenticated">
-                    <div
-                        class="box font-family--alt"
-                        style="background: var(--color-cool--200);">
-                        Signed-in as {{ userName }} </div>
+                    <div class="signed-in-box">
+                        Signed-in as {{ userName }}
+                    </div>
 
                     <div class="form-row">
                         <div class="form-row__label">
@@ -123,7 +122,7 @@
                 </div>
             </div>
         </div>
-        <div class="actions automation-cloud">
+        <div class="modal__buttons automation-cloud">
             <button class="button button--tertiary"
                 @click="$emit('hide')">
                 Cancel
@@ -314,21 +313,10 @@ export default {
     grid-gap: 2px;
 }
 
-.location-header {
-    font-family: var(--font-family--alt);
-    font-size: 1.6em;
-    margin-bottom: var(--gap--large);
-}
-
-.actions {
-    background: var(--color-cool--100);
-    padding: var(--gap) 0;
-    display: flex;
-    justify-content: flex-end;
-}
-
-.actions .button {
-    font-weight: 500;
-    font-size: 1.4em;
+/* TODO extract */
+.signed-in-box {
+    padding: var(--gap--large);
+    background: var(--color-cool--200);
+    border-radius: var(--border-radius);
 }
 </style>

--- a/packages/autopilot/stylesheets/_inbox.css
+++ b/packages/autopilot/stylesheets/_inbox.css
@@ -92,8 +92,3 @@ select option, option {
 .clickable {
     cursor: pointer;
 }
-
-.font-family--alt {
-    font-family: var(--font-family--alt);
-    font-size: 1.2em;
-}

--- a/packages/autopilot/stylesheets/components/modal.css
+++ b/packages/autopilot/stylesheets/components/modal.css
@@ -15,9 +15,12 @@
     display: flex;
     flex-flow: row nowrap;
     padding: var(--gap);
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
+
     background: var(--color-cool--700);
     color: #fff;
-    border-radius: var(--border-radius) var(--border-radius) 0 0;
+    font-family: var(--font-family--alt);
+    font-size: var(--font-size--alt);
 }
 
 .modal__header > i {
@@ -32,7 +35,10 @@
 }
 
 .modal__buttons {
-    margin-top: var(--gap);
     display: flex;
     justify-content: flex-end;
+    padding: var(--gap);
+
+    background: var(--color-cool--200);
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
 }

--- a/packages/autopilot/stylesheets/variables.css
+++ b/packages/autopilot/stylesheets/variables.css
@@ -3,9 +3,9 @@
     --gap--small: 6px;
 
     --font-size: 12px;
+    --font-size--alt: 14px;
     --font-size--small: 10px;
     --font-family--alt: 'Barlow Semi Condensed', sans-serif;
-    /* --font-family: var(--font-family--alt); */
 
     --tree-bar-size: 28px;
     --tree-icon-size: 28px;


### PR DESCRIPTION
I realise these changes just barely scratch the surface of what needs to be done, but it should provide a general direction.

More specifically, we should aim at:

- keeping components self-sufficient (i.e. `.automation-cloud > ` family of styles needs to be fixed with introducing more semantics)
- eventually removing `@ubio/css`, replacing it with just shared variables (because it's not maintained and it's hard to keep the changes in sync with it)
- if new common styles are introduced, they should follow general guidelines
- ad hoc styles are still possible, but should be minimised; `style="margin-left: var(--gap)"` is still viable — as long as it's just a single tweak (e.g. if we add more OR combine them with other scoped classes, then we don't use inline styles)

