### PR TITLE
fix: ui bugs on save/open

### DIFF
--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -82,7 +82,7 @@
                                     v-for="script of scripts"
                                     :key="script.id"
                                     :value="script.id">
-                                    {{ script.fullVersion }} - {{ new Date(script.createdAt) }}
+                                    {{ script.fullVersion }} - {{ formatDate(script.createdAt) || '' }}
                                 </option>
                             </select>
                         </div>
@@ -231,6 +231,19 @@ export default {
                     this.scripts = [];
                 }
             }
+        },
+
+        formatDate(timestamp) {
+            const time = new Date(timestamp);
+            return time.toLocaleString('en-GB', {
+                timeZone: 'UTC',
+                timeZoneName: 'short',
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+            });
         }
     },
 };

--- a/packages/autopilot/src/app/modals/save-automation.vue
+++ b/packages/autopilot/src/app/modals/save-automation.vue
@@ -81,14 +81,13 @@
                         <div class="form-row__label">
                             Script Version
                         </div>
-                        <div class="form-row__controls">
+                        <div class="form-row__controls group group--gap">
                             <input
-                                class="input input--inline"
-                                style="justify-self: stretch;"
+                                class="input"
                                 type="text"
                                 v-model="fullVersion"
                                 :readonly="release !== 'custom'" />
-                            <select class="input input--inline" v-model="release">
+                            <select class="input" v-model="release">
                                 <option value="major">major</option>
                                 <option value="minor">minor</option>
                                 <option value="patch">patch</option>
@@ -100,8 +99,8 @@
                         <div class="form-row__label">
                             Worker tag
                         </div>
-                        <div class="form-row__controls group group--gap">
-                            <input class="input"
+                        <div class="form-row__controls">
+                            <input class="input stretch"
                                 v-model="workerTag"/>
                         </div>
                     </div>
@@ -310,6 +309,7 @@ export default {
 .inline-message {
     font-style: italic;
     font-size: 10px;
+    color: var(--color-cool--600);
     line-height: 1.2em;
     padding: var(--gap) 2px;
     display: grid;


### PR DESCRIPTION
- keep `select` and `input` elements inlined when the width is narrow
<img src="https://user-images.githubusercontent.com/16660866/105885149-07fe2380-6009-11eb-9938-71054298a7d6.png" width="400">

- format time for scripts in Open modal
<img src="https://user-images.githubusercontent.com/16660866/105885179-13e9e580-6009-11eb-8811-452710faa52d.png" width="400">