### PR TITLE
feat: add searchable select component

### DIFF
--- a/packages/autopilot/src/app/components/service-select.vue
+++ b/packages/autopilot/src/app/components/service-select.vue
@@ -89,7 +89,7 @@ export default {
         },
 
         onBlur() {
-            if(this.hoverOnList) { // when losing focus to click the item, ignore
+            if (this.hoverOnList) { // when losing focus to click the item, ignore
                 return;
             }
             // when service is selected but the text is changed

--- a/packages/autopilot/src/app/components/service-select.vue
+++ b/packages/autopilot/src/app/components/service-select.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="search-select">
-        <div class="search-select__select input stretch"
+    <div class="service-select">
+        <div class="service-select__dropdown input stretch"
             @click="toggle"
             @blur="collapse">
             {{ serviceName || nullPlaceholder }}
@@ -8,23 +8,25 @@
                 <i class="fas fa-chevron-down"></i>
             </span>
         </div>
-        <div v-show="listShown" class="search-select__pane">
-            <input class="input stretch" type="search" v-model="searchText" placeholder="Search">
-            <div class="search-select__list">
-                <span v-if="services.length === 0"
-                    class="search-select__item"> No Automation found </span>
-                <span v-if="addNullOption"
-                    class="search-select__item"
-                    @click="onItemClick(null)">
-                    {{ nullPlaceholder }}
-                </span>
-                <span
-                    class="search-select__item"
-                    v-for="service of services"
-                    :key="service.id"
-                    @click="onItemClick(service)">
-                    {{ service.name }}
-                </span>
+        <div class="service-select__wrapper">
+            <div v-show="listShown" class="service-select__select">
+                <input class="input stretch" type="search" v-model="searchText" placeholder="Search">
+                <div class="service-select__list">
+                    <span v-if="services.length === 0"
+                        class="service-select__item"> No Automation found </span>
+                    <span v-if="addNullOption"
+                        class="service-select__item"
+                        @click="onItemClick(null)">
+                        {{ nullPlaceholder }}
+                    </span>
+                    <span
+                        class="service-select__item"
+                        v-for="service of services"
+                        :key="service.id"
+                        @click="onItemClick(service)">
+                        {{ service.name }}
+                    </span>
+                </div>
             </div>
         </div>
     </div>
@@ -98,30 +100,34 @@ export default {
 </script>
 
 <style scoped>
-.search-select__select {
+.service-select__dropdown {
     display: flex;
     justify-content: space-between;
     padding: 0 var(--gap--small);
     cursor: pointer;
 }
 
-.search-select__pane {
+.service-select__wrapper {
+    position: relative;
+}
+
+.service-select__select {
     position: absolute;
     z-index: 10;
     border-radius: var(--border-radius);
     border: solid 1px var(--border-color);
     background: var(--color-mono--000);
     padding: var(--gap--small);
-    width: 220px;
+    width: 100%;
 }
 
-.search-select__list {
+.service-select__list {
     margin: var(--gap--small) 0;
     max-height: 200px;
     overflow-y: auto;
 }
 
-.search-select__item {
+.service-select__item {
     display: block;
     cursor: pointer;
     height: var(--control-height);
@@ -129,7 +135,7 @@ export default {
     padding: var(--gap--small);
 }
 
-.search-select__item:hover {
+.service-select__item:hover {
     background: var(--color-cool--200);
 }
 </style>

--- a/packages/autopilot/src/app/components/service-select.vue
+++ b/packages/autopilot/src/app/components/service-select.vue
@@ -1,0 +1,121 @@
+<template>
+    <div class="search-select">
+        <div class="search-select__select input stretch"
+            @click="onSelctClick"
+            @blur="collapseList">
+            {{ serviceName || 'Select automation' }}
+            <span class="icon color--muted">
+                <i class="fas fa-chevron-down"></i>
+            </span>
+        </div>
+        <div v-show="listShown" class="search-select__pane">
+            <input class="input stretch" type="search" v-model="searchText" placeholder="Search">
+            <div class="search-select__list">
+                <span v-if="services.length === 0"
+                    class="search-select__item"> No Automation found </span>
+                <span
+                    class="search-select__item"
+                    v-for="service of services"
+                    :key="service.id"
+                    @click="selectService(service)">
+                    {{ service.name }}
+                </span>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    inject: [
+        'api',
+    ],
+
+    props: {
+        serviceId: String,
+        serviceName: String,
+    },
+
+    data() {
+        return {
+            services: [],
+            listShown: false,
+            searchText: '',
+        };
+    },
+    watch: {
+        searchText(val) {
+            this.loadServices(val);
+        }
+    },
+    methods: {
+        async loadServices(name = '') {
+            try {
+                this.services = await this.api.getServices({ name, archived: false });
+            } catch (error) {
+                this.services = [];
+            }
+        },
+
+        onSelctClick() {
+            if (this.listShown) {
+                this.collapseList();
+            } else {
+                this.expandList();
+            }
+        },
+
+        expandList() {
+            this.listShown = true;
+            this.loadServices();
+        },
+
+        collapseList() {
+            this.listShown = false;
+            this.searchText = '';
+        },
+
+        selectService(service) {
+            this.$emit('change', service);
+            this.collapseList();
+        }
+    },
+};
+</script>
+
+<style scoped>
+.search-select__select {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 var(--gap--small);
+    cursor: pointer;
+}
+
+.search-select__pane {
+    position: absolute;
+    z-index: 10;
+    border-radius: var(--border-radius);
+    border: solid 1px var(--border-color);
+    background: var(--color-mono--000);
+    padding: var(--gap--small);
+    width: 220px;
+}
+
+.search-select__list {
+    margin: var(--gap--small) 0;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.search-select__item {
+    display: block;
+    cursor: pointer;
+    height: var(--control-height);
+    text-overflow: ellipsis;
+    padding: var(--gap--small);
+}
+
+.search-select__item:hover {
+    background: var(--color-cool--200);
+}
+</style>

--- a/packages/autopilot/src/app/components/service-select.vue
+++ b/packages/autopilot/src/app/components/service-select.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="search-select">
         <div class="search-select__select input stretch"
-            @click="onSelctClick"
-            @blur="collapseList">
-            {{ serviceName || 'Select automation' }}
+            @click="toggle"
+            @blur="collapse">
+            {{ serviceName || nullPlaceholder }}
             <span class="icon color--muted">
                 <i class="fas fa-chevron-down"></i>
             </span>
@@ -13,11 +13,16 @@
             <div class="search-select__list">
                 <span v-if="services.length === 0"
                     class="search-select__item"> No Automation found </span>
+                <span v-if="addNullOption"
+                    class="search-select__item"
+                    @click="onItemClick(null)">
+                    {{ nullPlaceholder }}
+                </span>
                 <span
                     class="search-select__item"
                     v-for="service of services"
                     :key="service.id"
-                    @click="selectService(service)">
+                    @click="onItemClick(service)">
                     {{ service.name }}
                 </span>
             </div>
@@ -33,7 +38,12 @@ export default {
 
     props: {
         serviceId: String,
-        serviceName: String,
+        addNullOption: { type: Boolean, default: false },
+        nullPlaceholder: { type: String, default: 'Select automation' },
+    },
+
+    mounted() {
+        this.loadServices();
     },
 
     data() {
@@ -48,6 +58,12 @@ export default {
             this.loadServices(val);
         }
     },
+    computed: {
+        serviceName() {
+            const service = this.services.find(_ => _.id === this.serviceId);
+            return service ? service.name : null;
+        }
+    },
     methods: {
         async loadServices(name = '') {
             try {
@@ -56,28 +72,26 @@ export default {
                 this.services = [];
             }
         },
-
-        onSelctClick() {
+        toggle() {
             if (this.listShown) {
-                this.collapseList();
+                this.collapse();
             } else {
-                this.expandList();
+                this.expand();
             }
         },
-
-        expandList() {
+        expand() {
             this.listShown = true;
             this.loadServices();
         },
 
-        collapseList() {
+        collapse() {
             this.listShown = false;
             this.searchText = '';
         },
 
-        selectService(service) {
+        onItemClick(service) {
             this.$emit('change', service);
-            this.collapseList();
+            this.collapse();
         }
     },
 };

--- a/packages/autopilot/src/app/components/service-select.vue
+++ b/packages/autopilot/src/app/components/service-select.vue
@@ -2,16 +2,19 @@
     <div class="service-select">
         <div class="input stretch">
             <input class="service-select__multi"
+                v-model="text"
                 @focus="expand"
                 @blur="onBlur"
-                v-model="text"
                 :placeholder="placeholder">
-                <span class="icon"
+                <span
+                    class="icon"
                     @click="toggle()">
                     <i class="fas fa-chevron-down"></i>
                 </span>
         </div>
-        <div v-show="listShown" class="service-select__list"
+        <div
+            v-show="listShown"
+            class="service-select__list"
             @mouseover="hoverOnList = true;"
             @mouseout="hoverOnList = false;" >
             <div class="service-select__options">
@@ -40,10 +43,6 @@ export default {
         placeholder: { type: String, default: 'Search or select' },
     },
 
-    mounted() {
-        this.loadServices();
-    },
-
     data() {
         return {
             services: [],
@@ -52,6 +51,7 @@ export default {
             hoverOnList: false,
         };
     },
+
     watch: {
         text(val) {
             this.loadServices(val);
@@ -62,6 +62,11 @@ export default {
             }
         }
     },
+
+    created () {
+        this.loadServices();
+    },
+
     methods: {
         async loadServices(name = '') {
             try {

--- a/packages/autopilot/src/app/controllers/api.ts
+++ b/packages/autopilot/src/app/controllers/api.ts
@@ -24,7 +24,7 @@ export interface RequestOptions {
 }
 
 @injectable()
-@controller()
+@controller({ alias: 'api' })
 export class ApiController {
     constructor(
         @inject(ApiRequest)

--- a/packages/autopilot/src/app/controllers/app-menu.ts
+++ b/packages/autopilot/src/app/controllers/app-menu.ts
@@ -154,6 +154,10 @@ export class AppMenuController {
             click: () => this.saveload.openAutomation(),
         };
         yield {
+            label: 'Load as diff base...',
+            click: () => this.saveload.loadAsDiff(),
+        };
+        yield {
             label: 'Save Automation',
             accelerator: 'CmdOrCtrl+S',
             click: () => this.saveload.saveAutomation(),
@@ -162,6 +166,10 @@ export class AppMenuController {
             label: 'Save Automation As...',
             accelerator: 'CmdOrCtrl+Shift+S',
             click: () => this.saveload.saveAutomationAs(),
+        };
+        yield {
+            label: 'Manage Automation versions',
+            click: () => this.saveload.openAutomationManage(),
         };
         if (this.autosave.files.length > 0) {
             const groups = helpers.groupBy(this.autosave.files, file => file.split('_')[0]);

--- a/packages/autopilot/src/app/controllers/saveload.ts
+++ b/packages/autopilot/src/app/controllers/saveload.ts
@@ -104,22 +104,11 @@ export class SaveLoadController {
         activate: boolean;
         note: string;
     }) {
-<<<<<<< HEAD
         const { serviceId, fullVersion, workerTag, activate, note = '' } = spec;
         const automation = this.project.automation;
         automation.metadata.serviceId = serviceId;
         automation.metadata.version = fullVersion;
         const content = this.prepareScriptContent(automation);
-=======
-        const { serviceId, serviceName, fullVersion, workerTag, activate, note = '' } = spec;
-        const automation = { ...this.project.automation };
-        const metadata = {
-            ...automation.metadata,
-            version: fullVersion,
-            serviceId,
-            serviceName,
-        };
->>>>>>> feat: use service-select component in save-automation
         const script = await this.api.createScript({
             serviceId,
             fullVersion,
@@ -191,7 +180,6 @@ export class SaveLoadController {
         this.update();
     }
 
-    // apis
     async getActiveScriptId(serviceId: string) {
         const service = await this.getService(serviceId);
         return service.scriptId || null;

--- a/packages/autopilot/src/app/controllers/saveload.ts
+++ b/packages/autopilot/src/app/controllers/saveload.ts
@@ -98,16 +98,28 @@ export class SaveLoadController {
 
     async saveAutomationToAc(spec: {
         serviceId: string;
+        serviceName: string;
         fullVersion: string;
         workerTag: string;
         activate: boolean;
         note: string;
     }) {
+<<<<<<< HEAD
         const { serviceId, fullVersion, workerTag, activate, note = '' } = spec;
         const automation = this.project.automation;
         automation.metadata.serviceId = serviceId;
         automation.metadata.version = fullVersion;
         const content = this.prepareScriptContent(automation);
+=======
+        const { serviceId, serviceName, fullVersion, workerTag, activate, note = '' } = spec;
+        const automation = { ...this.project.automation };
+        const metadata = {
+            ...automation.metadata,
+            version: fullVersion,
+            serviceId,
+            serviceName,
+        };
+>>>>>>> feat: use service-select component in save-automation
         const script = await this.api.createScript({
             serviceId,
             fullVersion,

--- a/packages/autopilot/src/app/controllers/tools.ts
+++ b/packages/autopilot/src/app/controllers/tools.ts
@@ -70,9 +70,11 @@ export class ToolsController {
         await this.project.loadAutomationJson({
             script: scriptData.script,
             metadata: {
+                ...scriptData.metadata,
                 domainId: service.domain,
                 serviceId,
-                ...scriptData.metadata,
+                serviceName: service.name,
+                draft: service.draft,
             }
         });
     }

--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -117,6 +117,11 @@ export default {
         'project',
         'apiLogin',
     ],
+
+    components: {
+        ServiceSelect,
+    },
+
     data() {
         const { serviceId, serviceName } = this.project.automation.metadata;
         return {
@@ -125,13 +130,8 @@ export default {
             serviceName,
             scriptId: null,
             openActive: true,
-            services: [],
             scripts: [],
         };
-    },
-
-    components: {
-        ServiceSelect,
     },
 
     watch: {

--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -47,17 +47,10 @@
                             Automation
                         </div>
                         <div class="form-row__controls">
-                            <select v-model="serviceId" class="input stretch">
-                                <option v-if="services.length === 0"> No Automation found </option>
-                                <option v-else
-                                    :value="null"> Select Automation </option>
-                                <option
-                                    v-for="service of services"
-                                    :key="service.id"
-                                    :value="service.id">
-                                    {{ service.name }}
-                                </option>
-                            </select>
+                            <service-select
+                                :serviceId="serviceId"
+                                :serviceName="serviceName"
+                                @change="onServiceChange"></service-select>
                         </div>
                     </div>
                     <div class="form-row">
@@ -116,6 +109,7 @@
 <script>
 import { remote } from 'electron';
 const { dialog } = remote;
+import ServiceSelect from '../components/service-select.vue';
 
 export default {
     inject: [
@@ -124,10 +118,11 @@ export default {
         'apiLogin',
     ],
     data() {
-        const { serviceId } = this.project.automation.metadata;
+        const { serviceId, serviceName } = this.project.automation.metadata;
         return {
             location: this.saveload.location || 'ac',
             serviceId,
+            serviceName,
             scriptId: null,
             openActive: true,
             services: [],
@@ -135,16 +130,11 @@ export default {
         };
     },
 
-    created() {
-        this.loadServices();
+    components: {
+        ServiceSelect,
     },
 
     watch: {
-        isAuthenticated(val) {
-            if (val) {
-                this.loadServices();
-            }
-        },
         serviceId(val) {
             this.scriptId = null;
             if (!this.openActive && val) {
@@ -214,14 +204,6 @@ export default {
             }
         },
 
-        async loadServices() {
-            try {
-                this.services = await this.saveload.getServices();
-            } catch (error) {
-                this.services = [];
-            }
-        },
-
         async loadScripts(serviceId) {
             if (serviceId) {
                 try {
@@ -244,6 +226,11 @@ export default {
                 hour: '2-digit',
                 minute: '2-digit',
             });
+        },
+
+        onServiceChange(service) {
+            this.serviceId = service.id;
+            this.serviceName = service.name;
         }
     },
 };

--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -10,13 +10,15 @@
                     </div>
                 <div class="form-row">
                     <div class="form-row__controls">
-                        <input class="input"
+                        <input
+                            class="input"
                             type="radio"
                             id="location-ac"
-                            v-model="location"
-                            value="ac"/>
+                            value="ac"
+                            v-model="location" />
 
-                        <label class="form-row__label"
+                        <label
+                            class="form-row__label"
                             for="location-ac">
                             Automation Cloud
                         </label>
@@ -24,12 +26,14 @@
                 </div>
                 <div class="form-row">
                     <div class="form-row__controls">
-                        <input class="input"
+                        <input
                             type="radio"
+                            class="input"
                             id="location-file"
-                            v-model="location"
-                            value="file"/>
-                        <label class="form-row__label"
+                            value="file"
+                            v-model="location" />
+                        <label
+                            class="form-row__label"
                             for="location-file">
                             Your computer
                         </label>
@@ -48,8 +52,8 @@
                         </div>
                         <div class="form-row__controls">
                             <service-select
-                                :service="service"
-                                @change="onServiceSelect">
+                                @change="onServiceSelect"
+                                :service="service" >
                             </service-select>
                         </div>
                     </div>
@@ -61,18 +65,21 @@
                             </label>
                         </div>
                     </div>
-                    <div class="form-row" v-if="!openActive">
+                    <div v-if="!openActive"
+                        class="form-row" >
                         <div class="form-row__label">
                             Script version
                         </div>
                         <div class="form-row__controls">
-                            <select v-model="scriptId" class="select stretch">
+                            <select class="select stretch"
+                                v-model="scriptId">
                                 <option v-if="scripts.length === 0"
-                                    :value="null"> No script found </option>
-                                <option v-else
+                                    :value="null">
+                                     No script found
+                                </option>
+                                <option  v-else
                                     :value="null"> Version </option>
-                                <option
-                                    v-for="script of scripts"
+                                <option v-for="script of scripts"
                                     :key="script.id"
                                     :value="script.id">
                                     {{ script.fullVersion }} - {{ formatDate(script.createdAt) || '' }}
@@ -85,19 +92,17 @@
         </div>
         <div class="modal__buttons group group--gap">
             <button class="button button--alt button--tertiary"
-                @click="$emit('hide')">
+                @click="$emit('hide')" >
                 Cancel
             </button>
-            <button
-                v-if="location === 'ac'"
+            <button v-if="location === 'ac'"
                 class="button button--alt  button--primary"
-                @click="openFromAc()"
-                :disabled="!canOpenFromAc">
+                :disabled="!canOpenFromAc"
+                @click="openFromAc()">
                 Open
             </button>
 
-            <button
-                v-if="location === 'file'"
+            <button v-if="location === 'file'"
                 class="button button--alt button--primary"
                 @click="openFromFile()">
                 Select file
@@ -112,16 +117,16 @@ const { dialog } = remote;
 import ServiceSelect from '../components/service-select.vue';
 
 export default {
+    components: {
+        ServiceSelect,
+    },
+
     inject: [
         'saveload',
         'project',
         'apiLogin',
         'api',
     ],
-
-    components: {
-        ServiceSelect,
-    },
 
     data() {
         return {
@@ -148,13 +153,6 @@ export default {
         }
     },
 
-    created() {
-        const { serviceId } = this.project.automation.metadata;
-        if (serviceId && this.isAuthenticated) {
-            this.loadService(serviceId);
-        }
-    },
-
     watch: {
         isAuthenticated(val) {
             if (val) {
@@ -174,6 +172,13 @@ export default {
                 this.scripts = [];
             }
         },
+    },
+
+    created() {
+        const { serviceId } = this.project.automation.metadata;
+        if (serviceId && this.isAuthenticated) {
+            this.loadService(serviceId);
+        }
     },
 
     methods: {

--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="modal">
         <div class="modal__header">
-            Open
+            {{ modalTitle }}
         </div>
         <div class="modal__body">
             <div>
@@ -143,6 +143,10 @@ export default {
         canOpenFromAc() {
             return this.scriptId;
         },
+        modalTitle() {
+            console.log(this.saveload.setDiffBase);
+            return this.saveload.setDiffBase ? 'Open' : 'Load as diff base';
+        }
     },
 
     watch: {

--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -36,7 +36,7 @@
                     </div>
                 </div>
             </div>
-            <div v-if="location === 'ac'">
+            <div v-show="location === 'ac'">
                 <signin-warning message="to open automation from the Automation Cloud" />
                 <div v-if="isAuthenticated">
                     <div class="box box--light">
@@ -66,7 +66,7 @@
                             Script version
                         </div>
                         <div class="form-row__controls">
-                            <select v-model="scriptId" class="input stretch">
+                            <select v-model="scriptId" class="select stretch">
                                 <option v-if="scripts.length === 0"
                                     :value="null"> No script found </option>
                                 <option v-else
@@ -144,12 +144,27 @@ export default {
             return this.scriptId;
         },
         modalTitle() {
-            console.log(this.saveload.setDiffBase);
             return this.saveload.setDiffBase ? 'Open' : 'Load as diff base';
         }
     },
 
+    created() {
+        const { serviceId } = this.project.automation.metadata;
+        if (serviceId && this.isAuthenticated) {
+            this.loadService(serviceId);
+        }
+    },
+
     watch: {
+        isAuthenticated(val) {
+            if (val) {
+                const { serviceId } = this.project.automation.metadata;
+                this.loadService(serviceId);
+            } else {
+                this.service = null;
+            }
+        },
+
         async service(val) {
             if (val) {
                 this.scriptId = val.scriptId;
@@ -207,6 +222,15 @@ export default {
                     this.scripts = [];
                 }
             }
+        },
+
+        async loadService(serviceId) {
+            try {
+                this.service = await this.api.getService(serviceId);
+            } catch (error) {
+                console.warn('failed to load service', error);
+            }
+
         },
 
         formatDate(timestamp) {

--- a/packages/autopilot/src/app/modals/save-automation.vue
+++ b/packages/autopilot/src/app/modals/save-automation.vue
@@ -56,12 +56,11 @@
                             </span>
                         </div>
                     </div>
-                    <div class="box box--yellow box--small"
-                            v-if="namesMismatch">
+                    <div v-if="serviceIdMismatch"
+                        class="box box--yellow box--small">
                         <strong>Warning!</strong>
-                        Selected automation name <strong>{{ serviceName }}</strong> does not match
-                        current automation name <strong>{{ metadata.serviceName }}</strong>.
-                        it will update the service name to {{ metadata.serviceName }}.
+                        You are saving your script to a different automation, <strong>{{ serviceName }}</strong>.
+                        It will update the automation name to {{ metadata.serviceName }}.
                         Proceed at your own risk.
                     </div>
                     <div v-if="!serviceId"
@@ -212,7 +211,7 @@ export default {
         latestVersion() {
             return this.scripts[0] ? this.scripts[0].fullVersion : '0.0.0';
         },
-        namesMismatch() {
+        serviceIdMismatch() {
             return this.serviceId && this.serviceId !== this.metadata.serviceId;
         },
         fullVersion: {
@@ -237,7 +236,7 @@ export default {
             try {
                 await this.saveload.saveAutomationToAc({
                     serviceId: this.serviceId,
-                    seerviceName: this.serviceName,
+                    serviceName: this.serviceName,
                     fullVersion: this.fullVersion,
                     workerTag: this.workerTag,
                     activate: this.activate,

--- a/packages/autopilot/src/app/modals/save-automation.vue
+++ b/packages/autopilot/src/app/modals/save-automation.vue
@@ -23,10 +23,10 @@
                 <div class="form-row">
                     <div class="form-row__controls">
                         <input class="input"
+                            v-model="location"
                             type="radio"
                             id="location-file"
-                            v-model="location"
-                            value="file"/>
+                            value="file" />
                         <label class="form-row__label"
                             for="location-file">
                             Your computer
@@ -47,8 +47,8 @@
                         <div class="form-row__controls">
                              <service-select
                                 :service="service"
-                                placeholder="Create new automation"
-                                @change="onServiceSelect">
+                                @change="onServiceSelect"
+                                placeholder="Create new automation">
                             </service-select>
                             <span class="inline-message">
                                 <i class="fas fa-exclamation-circle"></i>
@@ -77,7 +77,8 @@
                             Version
                         </div>
                         <div class="form-row__controls">
-                            <select class="select stretch" v-model="release">
+                            <select class="select stretch"
+                                v-model="release">
                                 <option value="patch"> Increment patch version to {{ getVersion('patch') }} </option>
                                 <option value="minor"> Increment minor version to {{ getVersion('minor') }} </option>
                                 <option value="major"> Increment major version to {{ getVersion('major') }} </option>
@@ -89,20 +90,19 @@
                          class="form-row">
                         <div class="form-row__label"></div>
                         <div>
-                            <input
-                                class="input"
+                            <input class="input"
                                 type="text"
                                 v-model="fullVersion"/>
                         </div>
                     </div>
                     <div class="expand clickable"
                         @click="expandAdvanced = !expandAdvanced">
-                        <i
-                            class="fas"
+                        <i class="fas"
                             :class="{
                                 'fa-caret-right': !expandAdvanced,
                                 'fa-caret-down': expandAdvanced
-                            }"></i>
+                            }">
+                        </i>
                         <span>Advanced</span>
                     </div>
                     <div v-if="expandAdvanced">
@@ -116,11 +116,15 @@
                             </div>
                         </div>
                         <div class="form-row">
-                            <div class="form-row__label" style="align-self: flex-start;">
+                            <div class="form-row__label"
+                                style="align-self: flex-start;">
                                 Note
                             </div>
                             <div class="form-row__controls">
-                                <textarea class="textarea" v-model="note" rows="6"></textarea>
+                                <textarea class="textarea"
+                                    v-model="note"
+                                    rows="6">
+                                </textarea>
                             </div>
                         </div>
 
@@ -141,15 +145,13 @@
                 @click="$emit('hide')">
                 Cancel
             </button>
-            <button
-                v-if="location === 'ac'"
+            <button  v-if="location === 'ac'"
                 class="button button--alt button--primary"
                 @click="saveToAc()"
                 :disabled="!canSaveToAc">
                 Save
             </button>
-            <button
-                v-if="location === 'file'"
+            <button v-if="location === 'file'"
                 class="button button--alt button--primary"
                 @click="saveToFile()">
                 Save File
@@ -165,16 +167,16 @@ const { dialog } = remote;
 import ServiceSelect from '../components/service-select.vue';
 
 export default {
+    components: {
+        ServiceSelect,
+    },
+
     inject: [
         'saveload',
         'project',
         'apiLogin',
         'api',
     ],
-
-    components: {
-        ServiceSelect,
-    },
 
     data() {
         return {
@@ -189,32 +191,6 @@ export default {
             scripts: [],
             expandAdvanced: false,
         };
-    },
-
-    created() {
-        const { serviceId } = this.project.automation.metadata;
-        if (serviceId && this.isAuthenticated) {
-            this.loadService(serviceId);
-        }
-    },
-
-    watch: {
-        isAuthenticated(val) {
-            if (val) {
-                const { serviceId } = this.project.automation.metadata;
-                this.loadService(serviceId);
-            } else {
-                this.service = null;
-            }
-        },
-
-        service(val) {
-            if (val) {
-                this.loadScripts(val.id);
-            } else {
-                this.scripts = [];
-            }
-        },
     },
 
     computed: {
@@ -249,6 +225,32 @@ export default {
             set(val) {
                 this.customVersion = val;
             }
+        }
+    },
+
+    watch: {
+        isAuthenticated(val) {
+            if (val) {
+                const { serviceId } = this.project.automation.metadata;
+                this.loadService(serviceId);
+            } else {
+                this.service = null;
+            }
+        },
+
+        service(val) {
+            if (val) {
+                this.loadScripts(val.id);
+            } else {
+                this.scripts = [];
+            }
+        },
+    },
+
+    created() {
+        const { serviceId } = this.project.automation.metadata;
+        if (serviceId && this.isAuthenticated) {
+            this.loadService(serviceId);
         }
     },
 

--- a/packages/autopilot/src/app/modals/save-automation.vue
+++ b/packages/autopilot/src/app/modals/save-automation.vue
@@ -34,7 +34,7 @@
                     </div>
                 </div>
             </div>
-            <div v-if="location === 'ac'">
+            <div v-show="location === 'ac'">
                 <signin-warning message="to save and run automations in the Automation Cloud" />
                 <div v-if="isAuthenticated">
                     <div class="box box--light">
@@ -77,7 +77,7 @@
                             Version
                         </div>
                         <div class="form-row__controls">
-                            <select class="input stretch" v-model="release">
+                            <select class="select stretch" v-model="release">
                                 <option value="patch"> Increment patch version to {{ getVersion('patch') }} </option>
                                 <option value="minor"> Increment minor version to {{ getVersion('minor') }} </option>
                                 <option value="major"> Increment major version to {{ getVersion('major') }} </option>

--- a/packages/autopilot/src/app/viewports/script-editor/edit-default.vue
+++ b/packages/autopilot/src/app/viewports/script-editor/edit-default.vue
@@ -2,7 +2,7 @@
     <div class="edit-default section">
 
         <div class="form-row">
-            <div class="form-row__label section__title">Automation</div>
+            <div class="form-row__label">Automation</div>
             <div class="form-row__controls">
                 <input
                     class="input"

--- a/packages/autopilot/src/app/viewports/script-editor/edit-default.vue
+++ b/packages/autopilot/src/app/viewports/script-editor/edit-default.vue
@@ -2,7 +2,7 @@
     <div class="edit-default section">
 
         <div class="form-row">
-            <div class="form-row__label">Automation</div>
+            <div class="form-row__label section__title">Automation</div>
             <div class="form-row__controls">
                 <input
                     class="input"
@@ -13,9 +13,10 @@
 
         <edit-metadata/>
 
+        <hr>
         <div class="edit-default__pattern"
             @contextmenu.stop.prevent="popupMenu">
-            <div class="section__subtitle">
+            <div class="section__title">
                 Request Blocking
             </div>
 
@@ -32,7 +33,7 @@
                 </button>
             </div>
 
-            <button class="button button--primary button--flat"
+            <button class="button button--alt button--primary"
                 @click="popupAddBlockedPattern()">
                 <i class="button__icon fas fa-plus">
                 </i>

--- a/packages/autopilot/stylesheets/_inbox.css
+++ b/packages/autopilot/stylesheets/_inbox.css
@@ -24,6 +24,8 @@
 
 .input {
     box-shadow: none;
+    border-radius: 2px;
+    border-color: var(--color-mono--600);
 }
 
 .input.input--inline {
@@ -74,4 +76,9 @@ select option, option {
 
 .clickable {
     cursor: pointer;
+}
+
+.textarea {
+    border-radius: 2px;
+    border-color: var(--color-mono--600);
 }

--- a/packages/autopilot/stylesheets/_inbox.css
+++ b/packages/autopilot/stylesheets/_inbox.css
@@ -82,3 +82,13 @@ select option, option {
     border-radius: 2px;
     border-color: var(--color-mono--600);
 }
+
+.select {
+    background-color: var(--ui-color--white);
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" fill="black"><path d="M480 344.2L268.9 131.9c-15.8-15.9-41.3-15.9-57.1 0 -15.8 15.9-15.8 41.6 0 57.4l237.6 238.9c8.4 8.5 19.6 12.3 30.6 11.7 11 0.6 22.2-3.2 30.6-11.7l237.6-238.9c15.8-15.9 15.8-41.6 0-57.4s-41.3-15.9-57.1 0L480 344.2z"/></svg>');
+    position: relative;
+    box-shadow: none;
+    border-radius: 2px;
+    border: 1px solid var(--color-mono--600);
+    background-position: right 2px center;
+}


### PR DESCRIPTION
Spec can be found here: https://ubio-automation.atlassian.net/browse/ROBO-399
it includes:
- input+select for services list
- File > load as diff: show diff between current automation + loading automation
- File > Manage automation version: open dashboard's script version page
- Added `.select` style so we don't need to use `.input` class for select, also align with the spec

todo: 
- [x] align icons for `service-select` and native `select`
- [x]  load service if available when `Open` modal is shown
- [x]  fix when switching from save to ac > file > ac, it removes the selected service 