### PR TITLE
chore: return input stage back for QA tool

### DIFF
--- a/packages/autopilot/src/app/controllers/bundles.ts
+++ b/packages/autopilot/src/app/controllers/bundles.ts
@@ -84,10 +84,6 @@ export class BundlesController {
         return current;
     }
 
-    getPublicBundles(): Bundle[] {
-        return this.bundles.filter(bundle => !bundle.excluded);
-    }
-
     createBundle(spec: Bundle = {
         name: 'Input data',
         inputs: [],

--- a/packages/autopilot/src/app/controllers/project.ts
+++ b/packages/autopilot/src/app/controllers/project.ts
@@ -113,13 +113,6 @@ export class ProjectController {
         return script;
     }
 
-    updateMetadata(json: any) {
-        this.automation.metadata = {
-            ...DEFAULT_AUTOMATION_METADATA,
-            ...json,
-        };
-    }
-
     async loadFromAutosave(filename: string) {
         try {
             const file = path.join(this.autosave.autosaveDir, filename);

--- a/packages/engine/package-lock.json
+++ b/packages/engine/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@automationcloud/uniproxy": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@automationcloud/uniproxy/-/uniproxy-1.8.0.tgz",
-      "integrity": "sha512-GBTSKT6KO80utCWwOkajhBkaEvTxXRHEYRkxss7jR63bugcJnpqk1xf/dyXihu+tnWXFGkn1hZ8tIEhWdWMzCA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@automationcloud/uniproxy/-/uniproxy-1.8.1.tgz",
+      "integrity": "sha512-PBkRoBD13m2IJLFOrAv7IWLTJyMMX1jzLrIUovml0j7XGuU0EgUaHSrtBjeTKcwAg1+f6X98iEQn90ZK64DtOw==",
       "requires": {
         "@types/lru-cache": "^5.1.0",
         "@types/node-forge": "^0.9.5",
@@ -272,9 +272,9 @@
       }
     },
     "@types/node-forge": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-0.9.6.tgz",
-      "integrity": "sha512-lSy1BQxXQno8EzlCA9RATMzO6iIuBrlDrzB/GFC2yyObcLKDpwxY2YEivvSHdpLizeY9QLW7I4CadZx5ryV3bg==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-0.9.7.tgz",
+      "integrity": "sha512-AX7Mqk5ztzSvxqsA/q8y0k0/znJpW6QAqnoLQMEi7A3tio+laRmC/8Q3gbATHT4kZnvhnDmGAy1CpWFzlzCfeA==",
       "requires": {
         "@types/node": "*"
       }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@automationcloud/cdp": "^34.0.6",
         "@automationcloud/request": "^3.0.5",
-        "@automationcloud/uniproxy": "^1.8.0",
+        "@automationcloud/uniproxy": "^1.8.1",
         "@types/diacritics": "^1.3.1",
         "@types/escape-html": "^1.0.0",
         "@types/fast-levenshtein": "0.0.1",


### PR DESCRIPTION
This brings back `stage: ''` which unblocks QA for the time being. The whole thing is booby-trapped with TODOs, so we don't forget to revisit this.

Note: I tried to consolidate the workarounds in one place, hence cleaned up some stuff. I also applied the modifications directly to `metadata` (b/c I figured even if the save fails, we'll end up over-writing them on next save anyway). But lmk if I wasn't supposed to be doing that for any other reason 🙏