### PR TITLE
fix: get accessToken when initiating apiLogin

### DIFF
--- a/packages/autopilot/src/app/controllers/api-login.ts
+++ b/packages/autopilot/src/app/controllers/api-login.ts
@@ -60,6 +60,8 @@ export class ApiLoginController {
     }
 
     async init() {
+        // get accessToken before other api calls
+        await this.api.authAgent.getHeader();
         this.authenticate().catch(() => { });
     }
 
@@ -187,6 +189,7 @@ export class ApiLoginController {
         const request = new Request({
             baseUrl: accountUrl,
             auth: this.api.authAgent,
+            retryAttempts: 1,
         });
         const body = await request.get('');
         const valid = accountInfoValidator(body);


### PR DESCRIPTION
ticket: https://ubio-automation.atlassian.net/browse/ROBO-386

Issue accessToken(if available) in `init()` of apiLogin controller so we can avoid token invalidation race condition when requests are concurrently triggered