### PR TITLE
fix: remove setDiffBase event listener and loadDiffBase

### DIFF
--- a/packages/autopilot/src/app/controllers/project.ts
+++ b/packages/autopilot/src/app/controllers/project.ts
@@ -73,9 +73,6 @@ export class ProjectController {
                 this.reloadScript();
             }
         });
-        events.on('diffBaseSet', () => {
-            this.update();
-        });
     }
 
     async init() {

--- a/packages/autopilot/src/app/controllers/tools.ts
+++ b/packages/autopilot/src/app/controllers/tools.ts
@@ -79,11 +79,6 @@ export class ToolsController {
         });
     }
 
-    async loadScriptAsDiffBase(scriptId: string) {
-        const scriptData = await this.api.getScriptData(scriptId);
-        this.diff.setNewBase(scriptData.script);
-    }
-
     async loadHtmlSnapshot(htmlSnapshotId: string) {
         const snapshot = await this.api.getHtmlSnapshot(htmlSnapshotId);
         const { html } = snapshot;

--- a/packages/autopilot/src/app/modals/open-automation.vue
+++ b/packages/autopilot/src/app/modals/open-automation.vue
@@ -141,7 +141,7 @@ export default {
             return this.scriptId;
         },
         modalTitle() {
-            return this.saveload.setDiffBase ? 'Open' : 'Load as diff base';
+            return this.saveload.loadAsDiffBase ? 'Load as diff base' : 'Open';
         },
         scriptOptions() {
             return this.scripts.map(script => {

--- a/packages/autopilot/src/app/modals/save-automation.vue
+++ b/packages/autopilot/src/app/modals/save-automation.vue
@@ -361,7 +361,7 @@ export default {
         },
 
         async loadAsDiff() {
-            this.saveload.setDiffBase = false;
+            this.saveload.loadAsDiffBase = true;
             const latestScript = this.scripts[0];
             if (!this.service || !latestScript) {
                 this.showError(new Error('Service or valid version not found'));


### PR DESCRIPTION
ticket: https://ubio-automation.atlassian.net/browse/ROBO-427

diff base should not affect project's state, especially `project.automation.script` but the wrong event listener was set for `diffBaseSet` event and it unexpectedly updates the project's state that sometimes it saves an empty state after some of the actions mentioned in the ticket is performed.

This is also loosely related to how the `loadAsDiff` action is misunderstood, so I've renamed the `setAsDiff` property to loadAsDiff so it is more explicit, and update the project's state only when it's specified to `false` so thus we know setDiffBase is not related to updating project's state but separated operation.