### PR TITLE
feat: issue offline_access token for autopilot users

### DIFF
--- a/packages/autopilot/src/app/controllers/api-login.ts
+++ b/packages/autopilot/src/app/controllers/api-login.ts
@@ -122,7 +122,7 @@ export class ApiLoginController {
         const query = querystring.stringify({
             state,
             nonce,
-            scope: 'openid',
+            scope: 'offline_access',
             client_id: clientId,
             redirect_uri: this.getRedirectUrl(),
             response_type: 'code',


### PR DESCRIPTION
Related to https://ubio-automation.atlassian.net/browse/ROBO-386

As a Desktop application, it is fair to issue `offline_access` token so that it doesn't get affected by SSO sessions.
The token will be valid for 30 days as default, but it will be extended if a user uses the offline token for a refresh token action at least once per 30 days(we can change it to expire regardless of the refresh if we prefer). more details:  https://www.keycloak.org/docs/latest/server_admin/#_offline-access