### PR TITLE
fix: listen on accessToken change and fetch account when available

### DIFF
--- a/packages/autopilot/src/app/controllers/api-login.ts
+++ b/packages/autopilot/src/app/controllers/api-login.ts
@@ -54,7 +54,7 @@ export class ApiLoginController {
         @inject(ApiRequest)
         protected api: ApiRequest,
     ) {
-        this.events.on('apiAuthError', () => this.onAuthError());
+        this.events.on('apiAuthError', () => this.invalidateTokens());
         this.events.on('tokenUpdated', () => this.onTokenUpdated());
         ipcRenderer.on('acLoginResult', (_ev, code: string) => this.onAcLoginResult(code));
     }
@@ -70,7 +70,7 @@ export class ApiLoginController {
     }
 
     isAuthenticated(): boolean {
-        return !!this.api.authAgent.params.accessToken;
+        return !!this.api.authAgent.params.refreshToken;
     }
 
     get userInitial() {
@@ -136,7 +136,7 @@ export class ApiLoginController {
         wnd.focus();
     }
 
-    protected onAuthError() {
+    protected invalidateTokens() {
         this.api.authAgent.setTokens({});
         this.updateRefreshToken('');
     }

--- a/packages/autopilot/src/app/controllers/roxi.ts
+++ b/packages/autopilot/src/app/controllers/roxi.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ApiRequest, Configuration, ProxyService, uniproxy } from '@automationcloud/engine';
+import { Configuration, ProxyService, uniproxy } from '@automationcloud/engine';
 import { MenuItemConstructorOptions } from 'electron';
 import { inject, injectable } from 'inversify';
 
@@ -21,6 +21,7 @@ import { EventsController } from '../controllers/events';
 import { UserData } from '../userdata';
 import { popupMenu } from '../util/menu';
 import { ApiController, ProxyConfig } from './api';
+import { ApiLoginController } from './api-login';
 import { StorageController } from './storage';
 
 export type ProxyConnectionType = 'direct' | 'proxy';
@@ -43,8 +44,8 @@ export class RoxiController {
         protected events: EventsController,
         @inject(ApiController)
         protected api: ApiController,
-        @inject(ApiRequest)
-        protected apiRequest: ApiRequest,
+        @inject(ApiLoginController)
+        protected apiLogin: ApiLoginController,
         @inject(Configuration)
         protected config: Configuration,
         @inject(StorageController)
@@ -115,7 +116,7 @@ export class RoxiController {
     }
 
     isAuthenticated() {
-        return this.apiRequest.isAuthenticated();
+        return this.apiLogin.isAuthenticated();
     }
 
     isActive() {

--- a/packages/autopilot/src/app/views/account-menu.vue
+++ b/packages/autopilot/src/app/views/account-menu.vue
@@ -32,9 +32,10 @@ export default {
     methods: {
 
         popupMenu() {
+            const email = this.apiLogin.account ? this.apiLogin.account.email : 'Offline User';
             const menuItems = [
                 {
-                    label: 'Email: ' + this.apiLogin.account.email,
+                    label: 'Email: ' + email,
                     enabled: false,
                 },
                 {
@@ -49,7 +50,7 @@ export default {
                 {
                     label: 'Sign out',
                     click: () => {
-                        this.apiLogin.logout();
+                        this.apiLogin.invalidateTokens();
                     },
                 }
             ];

--- a/packages/engine/package-lock.json
+++ b/packages/engine/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@automationcloud/request": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-3.3.1.tgz",
-      "integrity": "sha512-IGMnH0vM0K+150Ex+DH2qV8J1Z6P8CNYzZAFp1EL9xmgLIZCZ34c8l98TpGtYPrCnJIkRobWCMQVAkh4HZvmvg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-3.3.2.tgz",
+      "integrity": "sha512-V238nnbVugSlcWYDqdDIsXfmJ7w7UKux8+sdJ227lMIXOoAwCYAR1lbPaspw0AMPGCyiZWtqD9vFOkAFnTpfCA==",
       "requires": {
         "@types/node-fetch": "^2.5.3",
         "node-fetch": "^2.6.1",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -21,7 +21,7 @@
     ],
     "dependencies": {
         "@automationcloud/cdp": "^34.10.0",
-        "@automationcloud/request": "^3.3.1",
+        "@automationcloud/request": "^3.3.2",
         "@automationcloud/uniproxy": "^1.8.2",
         "@types/diacritics": "^1.3.1",
         "@types/escape-html": "^1.0.0",

--- a/packages/engine/src/main/services/api-request.ts
+++ b/packages/engine/src/main/services/api-request.ts
@@ -48,10 +48,6 @@ export class ApiRequest {
         });
     }
 
-    isAuthenticated() {
-        return !!this.authAgent.params.refreshToken;
-    }
-
     get(url: string, options: RequestOptions = {}) {
         return this.request.get(url, options);
     }


### PR DESCRIPTION
https://ubio-automation.atlassian.net/browse/ROBO-456

As request library should not invalidate refreshToken and delegate the responsibility to a client, Autopilot is actively checking the refreshToken invalidation for `authAgent` and also listen to its accessToken's change so that it can actively update it's state(account information etc).

- removed `isAuthenticated` method from `engine/api-request` as it is used by autopilot only.
- renamed `apiAuthInvalidated` to `apiAuthError` as auth will be invalidated when this event event is emitted
- it is possible to fetch the account details even after `init` phase as it subscribes to accessToken changes.

There is still issue that there's no ability to automatically obtain the accessToken when the machine was offline and then back online. The refresh token is still intact but there's no trigger to obtain the accessToken. we might want to add a feature that 
listen on [online/oflline event](https://www.electronjs.org/docs/tutorial/online-offline-events) and trigger the request.