### PR TITLE
feat: make action composition disablable

### DIFF
--- a/packages/autopilot/src/app/viewports/settings/preferences.vue
+++ b/packages/autopilot/src/app/viewports/settings/preferences.vue
@@ -113,7 +113,7 @@
         </div>
 
         <div class="section__title">
-            Appearance
+            UI
         </div>
         <div class="pane">
             <div class="pane__item">
@@ -143,6 +143,15 @@
                         @input="setValue('UI_SHOW_FREQUENT_ITEMS', $event)"/>
                 </div>
             </div>
+            <div class="pane__item">
+                <div class="pane__main">
+                    Pre-compose common actions
+                </div>
+                <div class="pane__aside">
+                    <toggle :value="getValue('COMPOSITION_ENABLED')"
+                        @input="setValue('COMPOSITION_ENABLED', $event)"/>
+                </div>
+            </div>
         </div>
 
         <template v-if="devMode.isEnabled()">
@@ -156,10 +165,11 @@
 </template>
 
 <script>
-import UpdateChecker from './update-checker.vue';
 import { remote } from 'electron';
+
 import { vfx } from '../../util';
 import Configuration from './configuration.vue';
+import UpdateChecker from './update-checker.vue';
 
 const { dialog } = remote;
 

--- a/packages/autopilot/src/app/views/inspect.vue
+++ b/packages/autopilot/src/app/views/inspect.vue
@@ -1,0 +1,60 @@
+<template>
+    <div class="inspect"
+        v-if="inspect.isInspecting()">
+
+        <article class="inspect__content">
+            <h3>{{ prompt }} </h3>
+
+            <div class="inspect__controls">
+                <button class="button"
+                    @click="inspect.stopInspect()">
+                    Cancel
+                </button>
+            </div>
+        </article>
+
+    </div>
+</template>
+
+<script>
+export default {
+
+    inject: [
+        'inspect'
+    ],
+
+    computed: {
+
+        prompt() {
+            return this.inspect.options.prompt || 'Select an element on the page';
+        }
+
+    }
+
+};
+</script>
+
+<style scoped>
+.inspect {
+    z-index: 20000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    background: rgba(255, 255, 255, .85);
+}
+
+.inspect__content {
+    text-align: center;
+}
+
+.inspect__controls {
+    padding-top: var(--gap);
+}
+</style>

--- a/packages/autopilot/src/app/views/root.vue
+++ b/packages/autopilot/src/app/views/root.vue
@@ -17,6 +17,7 @@
             <modal-menu/>
             <notifications/>
             <bubbles/>
+            <inspect/>
         </div>
     </div>
 </template>
@@ -27,6 +28,7 @@ import '../../../stylesheets/index.css';
 import { dom } from '../util';
 import Bubbles from './bubbles.vue';
 import FirstRun from './first-run.vue';
+import Inspect from './inspect.vue';
 import Layout from './layout.vue';
 import ModalMenu from './modal-menu.vue';
 import Modals from './modals.vue';
@@ -47,6 +49,7 @@ export default {
         ModalMenu,
         Notifications,
         Bubbles,
+        Inspect,
     },
 
     inject: [

--- a/packages/autopilot/stylesheets/article.css
+++ b/packages/autopilot/stylesheets/article.css
@@ -8,10 +8,8 @@ article h1, article h2, article h3 {
 
 article h3 {
     margin-top: var(--gap--large);
-    color: var(--color-blue--600);
     font-weight: 400;
-    font-size: var(--font-size);
-    text-transform: uppercase;
+    font-size: var(--font-size--large);
 }
 
 article h4 {


### PR DESCRIPTION
This adds a preference to disable action composition.

One step further is to turn it off via inspect overlay — but I haven't yet figured a way to de-couple action composition and inspector (which is lower-level functionality).

Please lmk what you think @kyungeunni 