### PR TITLE
fix: build response to object so that it can be used from get outcome

### DIFF
--- a/packages/autopilot/src/app/controllers/credentials.ts
+++ b/packages/autopilot/src/app/controllers/credentials.ts
@@ -7,6 +7,7 @@ import {
     CredentialsOAuth2Data,
     HttpCallbackService,
     model,
+    OAuth1SignatureMethod,
     Pipe,
     StoredCredentials,
 } from '@automationcloud/engine';
@@ -115,7 +116,7 @@ export class CredentialsController {
                     data.requestTokenUrl = config.requestTokenUrl;
                     data.accessTokenUrl = config.accessTokenUrl;
                     data.userAuthorizationUrl = config.userAuthorizationUrl;
-                    data.signatureMethod = config.signatureMethod;
+                    data.signatureMethod = config.signatureMethod ?? OAuth1SignatureMethod.HMAC_SHA1;
                 }
                 const url = new URL('/v1/oauth', SSO_SERVICE_URL);
                 url.searchParams.set('requestTokenURL', data.requestTokenUrl);

--- a/packages/engine/src/main/connector-action.ts
+++ b/packages/engine/src/main/connector-action.ts
@@ -64,6 +64,11 @@ export abstract class ConnectorAction extends Action {
 
     get $endpoint() { return this.getEndpoint(); }
 
+    reset() {
+        super.reset();
+        this.$outcome = undefined;
+    }
+
     async exec() {
         // evaluate the parameters pipeline
         const data = await this.retry(async () => {
@@ -78,7 +83,15 @@ export abstract class ConnectorAction extends Action {
             baseUrl: this.$baseUrl,
             auth,
         });
-        this.$outcome = await request.sendRaw(method, path, options);
+        const response = await request.sendRaw(method, path, options);
+        const body = await response.text();
+        this.$outcome = {
+            url: response.url,
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+            body,
+        };
     }
 
     // compose request options and path by reading location and type of the parameters

--- a/packages/engine/src/main/services/credentials.ts
+++ b/packages/engine/src/main/services/credentials.ts
@@ -118,7 +118,7 @@ export interface CredentialsOAuth1Config {
     requestTokenUrl: string;
     accessTokenUrl: string;
     userAuthorizationUrl: string;
-    signatureMethod: r.OAuth1SignatureMethod;
+    signatureMethod?: r.OAuth1SignatureMethod;
     customConfig?: boolean;
     help?: string;
 }
@@ -127,7 +127,7 @@ export interface CredentialsOAuth1Data {
     requestTokenUrl: string;
     accessTokenUrl: string;
     userAuthorizationUrl: string;
-    signatureMethod?: r.OAuth1SignatureMethod;
+    signatureMethod: r.OAuth1SignatureMethod;
     consumerKey: string;
     consumerSecret: string;
 

--- a/packages/engine/src/main/services/credentials.ts
+++ b/packages/engine/src/main/services/credentials.ts
@@ -118,7 +118,7 @@ export interface CredentialsOAuth1Config {
     requestTokenUrl: string;
     accessTokenUrl: string;
     userAuthorizationUrl: string;
-    signatureMethod?: r.OAuth1SignatureMethod;
+    signatureMethod: r.OAuth1SignatureMethod;
     customConfig?: boolean;
     help?: string;
 }


### PR DESCRIPTION
Part of connectors.

I noticed that `Result`outcome is empty object when assigning the whole response, so that we needed to build an object out of response and return them. 