### PR TITLE
chore: improve create-credentials UI, update connector

### DIFF
--- a/packages/autopilot/src/app/modals/create-credentials.vue
+++ b/packages/autopilot/src/app/modals/create-credentials.vue
@@ -9,19 +9,20 @@
 
             <div class="form-row">
                 <div class="form-row__label">
-                    Auth Type
+                    Auth type
                 </div>
 
                 <div class="form-row__controls">
-                    <select class="select" v-model="selectedIndex">
+                    <template v-if="configs.length === 1">
+                        <span> {{ getConfigLabel(selectedConfig.type) }} </span>
+                    </template>
+                    <select v-else
+                        class="select" v-model="selectedIndex">
                         <option v-for="(conf, index) of configs"
                             :key="index"
                             :value="index"
                             @click="selectedIndex = index">
-                            <span v-if="conf.type === 'basic'">Basic</span>
-                            <span v-if="conf.type === 'bearer'">Bearer</span>
-                            <span v-if="conf.type === 'oauth1'">OAuth1</span>
-                            <span v-if="conf.type === 'oauth2'">OAuth2</span>
+                            {{ getConfigLabel(conf.type) }}
                         </option>
                     </select>
                 </div>
@@ -323,6 +324,10 @@ export default {
 
         toHumanLabel(gt) {
             return util.humanize(gt);
+        },
+
+        getConfigLabel(type) {
+            return util.capitalize(type.replace('oauth', 'OAuth'));
         },
 
         login() {

--- a/packages/autopilot/src/app/modals/create-credentials.vue
+++ b/packages/autopilot/src/app/modals/create-credentials.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="modal modal--narrow">
+    <div class="modal">
         <div class="modal__header">
             <i v-if="param.icon"
                 :class="param.icon"></i>
@@ -9,7 +9,7 @@
 
             <div class="form-row">
                 <div class="form-row__label">
-                    Auth type
+                    Auth Type
                 </div>
 
                 <div class="form-row__controls">
@@ -30,7 +30,7 @@
 
             <div class="form-row">
                 <div class="form-row__label">
-                    Login name
+                    Login Name
                 </div>
                 <div class="form-row__controls">
                     <input v-focus
@@ -269,7 +269,7 @@ export default {
     mounted() {
         // Infer login name from AC auth
         const { firstName } = this.apiLogin.account || {};
-        this.name = firstName;
+        this.name = firstName + ' - ' + this.providerName;
         // Pre-fill custom URLs for OAuth configs
         const oauth1Config = this.configs.find(_ => _.type === 'oauth1');
         if (oauth1Config) {
@@ -327,7 +327,12 @@ export default {
         },
 
         getConfigLabel(type) {
-            return util.capitalize(type.replace('oauth', 'OAuth'));
+            return {
+                basic: 'Basic',
+                bearer: 'Bearer',
+                oauth1: 'OAuth1',
+                oauth2: 'OAuth2',
+            }[type] || '';
         },
 
         login() {

--- a/packages/autopilot/src/app/modals/create-credentials.vue
+++ b/packages/autopilot/src/app/modals/create-credentials.vue
@@ -7,24 +7,25 @@
         </div>
         <div class="modal__body">
 
-            <template v-if="configs.length > 1">
-                <div class="nav-panel">
-                    <div class="group group--semi-merged">
-                        <button v-for="(conf, index) of configs"
+            <div class="form-row">
+                <div class="form-row__label">
+                    Auth Type
+                </div>
+
+                <div class="form-row__controls">
+                    <select class="select" v-model="selectedIndex">
+                        <option v-for="(conf, index) of configs"
                             :key="index"
-                            class="button"
-                            :class="{
-                                'button--accent': index === selectedIndex,
-                            }"
+                            :value="index"
                             @click="selectedIndex = index">
                             <span v-if="conf.type === 'basic'">Basic</span>
                             <span v-if="conf.type === 'bearer'">Bearer</span>
                             <span v-if="conf.type === 'oauth1'">OAuth1</span>
                             <span v-if="conf.type === 'oauth2'">OAuth2</span>
-                        </button>
-                    </div>
+                        </option>
+                    </select>
                 </div>
-            </template>
+            </div>
 
             <div class="form-row">
                 <div class="form-row__label">

--- a/packages/engine/src/main/connector.ts
+++ b/packages/engine/src/main/connector.ts
@@ -326,7 +326,7 @@ function getParametersJsonString(params: ConnectorParameter[]) {
         '{',
     ];
     params.forEach(param => {
-        str.push(`  "${param.key}": ${param.default ?? null}, // ${param.required ? '*' : ''}location: ${param.location}, ${param.description}`);
+        str.push(`  "${param.key}": ${param.default ?? null}, // ${param.required ? '*' : ''}${param.description}`);
     });
     str.push('}');
     return str.join('\n');


### PR DESCRIPTION
- chore: change nav buttons to select in create-crdt, but show as plane text when only one option available 
![image](https://user-images.githubusercontent.com/16660866/118121771-3eae4d00-b3f2-11eb-8823-037f325ce267.png)
![image](https://user-images.githubusercontent.com/16660866/118121985-83d27f00-b3f2-11eb-98ea-363a3ec86347.png)

Also changed the `create-credential` modal to be normal modal width instead of narrow as it break when there is a long lengthy of url, and it looks a bit packed when there are too many texts.

- fix: connectors: add ability to pass headers and body
 It's due to some body object can't be part of parameters(e.g. nested properties etc)