### PR TITLE
feat: configurable oauth2 scope when creating crendentials

### DIFF
--- a/packages/autopilot/src/app/controllers/credentials.ts
+++ b/packages/autopilot/src/app/controllers/credentials.ts
@@ -138,7 +138,6 @@ export class CredentialsController {
                 if (!config.customConfig) {
                     data.authorizationUrl = config.authorizationUrl;
                     data.tokenUrl = config.tokenUrl;
-                    data.scope = config.scope;
                 }
                 const url = new URL('/v1/oauth2', SSO_SERVICE_URL);
                 url.searchParams.set('authorizationURL', data.authorizationUrl);

--- a/packages/autopilot/src/app/modals/create-credentials.vue
+++ b/packages/autopilot/src/app/modals/create-credentials.vue
@@ -200,6 +200,17 @@
                             v-model.trim="oauth2.clientSecret"/>
                     </div>
                 </div>
+
+                <div class="form-row">
+                    <div class="form-row__label">
+                        Scopes
+                    </div>
+                    <div class="form-row__controls">
+                        <input type="text"
+                            class="input stretch"
+                            v-model.trim="oauth2.scope"/>
+                    </div>
+                </div>
             </div>
 
             <div class="help box box--blue"
@@ -259,6 +270,7 @@ export default {
             oauth2: {
                 clientId: '',
                 clientSecret: '',
+                scope: '',
                 // Those are only modified when `config.customConfig: true`
                 authorizationUrl: '',
                 tokenUrl: '',
@@ -280,6 +292,7 @@ export default {
         }
         const oauth2Config = this.configs.find(_ => _.type === 'oauth2');
         if (oauth2Config) {
+            this.oauth2.scope = oauth2Config.scope;
             this.oauth2.tokenUrl = oauth2Config.tokenUrl;
             this.oauth2.authorizationUrl = oauth2Config.authorizationUrl;
         }

--- a/packages/engine/src/main/connector.ts
+++ b/packages/engine/src/main/connector.ts
@@ -139,7 +139,6 @@ function buildConnectorClass(namespace: string, meta: ConnectorMetadata, endpoin
                 return el.value;
             });
             util.checkType(data, 'object', 'Parameters');
-            const { options, path } = this.getRequestSpec(data);
             const { method } = this.$endpoint;
             const auth = await this.$credentials.getAuthAgent(this.auth);
             const request = new r.Request({
@@ -209,9 +208,11 @@ function buildConnectorClass(namespace: string, meta: ConnectorMetadata, endpoin
             // convert body
             if (isFormData) {
                 options.headers!['content-type'] = 'application/x-www-form-urlencoded';
-                options.body = new URLSearchParams(options.body ?? {});
+                const url = new URLSearchParams(options.body ?? {});
+                options.body = url.toString();
+            } else {
+                options.body = options.body != null ? JSON.stringify(options.body) : null;
             }
-            options.body = options.body != null ? JSON.stringify(options.body) : null;
             return { options, path };
         }
     }

--- a/packages/engine/src/main/connector.ts
+++ b/packages/engine/src/main/connector.ts
@@ -139,6 +139,7 @@ function buildConnectorClass(namespace: string, meta: ConnectorMetadata, endpoin
                 return el.value;
             });
             util.checkType(data, 'object', 'Parameters');
+            const { options, path } = this.getRequestSpec(data);
             const { method } = this.$endpoint;
             const auth = await this.$credentials.getAuthAgent(this.auth);
             const request = new r.Request({
@@ -208,8 +209,8 @@ function buildConnectorClass(namespace: string, meta: ConnectorMetadata, endpoin
             // convert body
             if (isFormData) {
                 options.headers!['content-type'] = 'application/x-www-form-urlencoded';
-                const url = new URLSearchParams(options.body ?? {});
-                options.body = url.toString();
+                const formData = new URLSearchParams(options.body ?? {});
+                options.body = formData.toString();
             } else {
                 options.body = options.body != null ? JSON.stringify(options.body) : null;
             }


### PR DESCRIPTION
Allow users to set their own scopes, it is needed as a few providers's the default scope specified in spec won't work universally for all the methods.

![image](https://user-images.githubusercontent.com/16660866/118265984-40434800-b4ba-11eb-8ac6-897152fb1751.png)
