### PR TITLE
fix: do not collect pipeline feedback in workers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23341,11 +23341,11 @@
         },
         "packages/autopilot": {
             "name": "@automationcloud/autopilot",
-            "version": "34.14.5",
+            "version": "34.15.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@automationcloud/engine": "^34.14.5",
-                "@automationcloud/fuzzy-search": "^34.14.5",
+                "@automationcloud/engine": "^34.15.0",
+                "@automationcloud/fuzzy-search": "^34.15.0",
                 "@types/jsonpointer": "^4.0.0",
                 "@types/koa": "^2.11.4",
                 "@types/koa-bodyparser": "^4.3.0",
@@ -23561,7 +23561,7 @@
         },
         "packages/cdp": {
             "name": "@automationcloud/cdp",
-            "version": "34.14.5",
+            "version": "34.15.0",
             "dependencies": {
                 "@types/node-fetch": "^2.5.7",
                 "@types/rimraf": "^3.0.0",
@@ -23609,10 +23609,10 @@
         },
         "packages/engine": {
             "name": "@automationcloud/engine",
-            "version": "34.14.5",
+            "version": "34.15.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@automationcloud/cdp": "^34.14.5",
+                "@automationcloud/cdp": "^34.15.0",
                 "@automationcloud/request": "^3.3.2",
                 "@automationcloud/uniproxy": "^1.8.2",
                 "@types/diacritics": "^1.3.1",
@@ -23791,7 +23791,7 @@
         },
         "packages/fuzzy-search": {
             "name": "@automationcloud/fuzzy-search",
-            "version": "34.14.5",
+            "version": "34.15.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "fast-json-stable-stringify": "^2.1.0"
@@ -23809,10 +23809,10 @@
         },
         "packages/tools": {
             "name": "@automationcloud/autopilot-tools",
-            "version": "34.14.5",
+            "version": "34.15.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@automationcloud/engine": "^34.14.5",
+                "@automationcloud/engine": "^34.15.0",
                 "@types/diff": "^4.0.2",
                 "@types/inquirer": "^6.5.0",
                 "@types/marked": "^0.7.3",
@@ -23913,10 +23913,10 @@
         },
         "packages/worker": {
             "name": "@automationcloud/worker",
-            "version": "34.14.5",
+            "version": "34.15.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@automationcloud/engine": "^34.14.5",
+                "@automationcloud/engine": "^34.15.0",
                 "@types/koa": "^2.0.52",
                 "@types/lru-cache": "^5.1.0",
                 "@types/node-fetch": "^2.5.3",
@@ -24007,8 +24007,8 @@
         "@automationcloud/autopilot": {
             "version": "file:packages/autopilot",
             "requires": {
-                "@automationcloud/engine": "^34.14.5",
-                "@automationcloud/fuzzy-search": "^34.14.5",
+                "@automationcloud/engine": "^34.15.0",
+                "@automationcloud/fuzzy-search": "^34.15.0",
                 "@types/debounce": "^1.2.0",
                 "@types/debounce-promise": "^3.1.1",
                 "@types/json5": "^0.0.30",
@@ -24179,7 +24179,7 @@
         "@automationcloud/autopilot-tools": {
             "version": "file:packages/tools",
             "requires": {
-                "@automationcloud/engine": "^34.14.5",
+                "@automationcloud/engine": "^34.15.0",
                 "@types/diff": "^4.0.2",
                 "@types/inquirer": "^6.5.0",
                 "@types/marked": "^0.7.3",
@@ -24301,7 +24301,7 @@
         "@automationcloud/engine": {
             "version": "file:packages/engine",
             "requires": {
-                "@automationcloud/cdp": "^34.14.5",
+                "@automationcloud/cdp": "^34.15.0",
                 "@automationcloud/request": "^3.3.2",
                 "@automationcloud/uniproxy": "^1.8.2",
                 "@types/diacritics": "^1.3.1",
@@ -24488,7 +24488,7 @@
         "@automationcloud/worker": {
             "version": "file:packages/worker",
             "requires": {
-                "@automationcloud/engine": "^34.14.5",
+                "@automationcloud/engine": "^34.15.0",
                 "@types/ioredis": "^4.0.18",
                 "@types/json5": "^0.0.30",
                 "@types/koa": "^2.0.52",

--- a/packages/autopilot/src/app/controllers/script-editor.ts
+++ b/packages/autopilot/src/app/controllers/script-editor.ts
@@ -1,0 +1,28 @@
+import { booleanConfig } from '@automationcloud/engine';
+import { inject, injectable } from 'inversify';
+
+import { controller } from '../controller';
+import { SettingsController } from './settings';
+
+const UI_PIPE_FEEDBACK_ENABLED = booleanConfig('UI_PIPE_FEEDBACK_ENABLED', true);
+
+@injectable()
+@controller({
+    alias: 'scriptEditor',
+})
+export class ScriptEditorController {
+
+    constructor(
+        @inject(SettingsController)
+        protected settings: SettingsController,
+    ) {
+
+    }
+
+    async init() {}
+
+    isPipeFeedbackEnabled() {
+        return this.settings.get(UI_PIPE_FEEDBACK_ENABLED);
+    }
+
+}

--- a/packages/autopilot/src/app/viewports/script-editor/pipes/pipeline.vue
+++ b/packages/autopilot/src/app/viewports/script-editor/pipes/pipeline.vue
@@ -11,9 +11,9 @@
 <script>
 import debouncePromise from 'debounce-promise';
 
+import PipeList from './pipe-list.vue';
 import PipelineInput from './pipeline-input.vue';
 import PipelineOutcomes from './pipeline-outcomes.vue';
-import PipeList from './pipe-list.vue';
 
 const DEFAULT_STATE = {
     spotlight: {
@@ -27,6 +27,10 @@ const DEFAULT_STATE = {
 };
 
 export default {
+
+    inject: [
+        'scriptEditor'
+    ],
 
     components: {
         PipelineInput,
@@ -78,7 +82,7 @@ export default {
             this.error = null;
             this.introspectionResults = [];
             const ctx = pipeline.$action.createCtx();
-            ctx.$introspectionEnabled = true;
+            ctx.$introspectionEnabled = this.scriptEditor.isPipeFeedbackEnabled();
             ctx.$introspectionSpotlight = this.spotlight;
             try {
                 this.outcomes = await pipeline.selectAll(inputSet, ctx);

--- a/packages/autopilot/src/app/viewports/settings/preferences.vue
+++ b/packages/autopilot/src/app/viewports/settings/preferences.vue
@@ -125,6 +125,18 @@
                         @input="setValue('UI_DIFF_ENABLED', $event)"/>
                 </div>
             </div>
+            <div class="pane__item"
+                v-if="devMode.isEnabled()">
+                <div class="pane__main">
+                    Enable Pipeline feedback
+                    <i class="fas fa-question-circle icon-help"
+                        title="This will disable intermediate results in pipelines."></i>
+                </div>
+                <div class="pane__aside">
+                    <toggle :value="getValue('UI_PIPE_FEEDBACK_ENABLED')"
+                        @input="setValue('UI_PIPE_FEEDBACK_ENABLED', $event)"/>
+                </div>
+            </div>
             <div class="pane__item">
                 <div class="pane__main">
                     Show verbose feedback in Pipelines

--- a/packages/engine/src/main/ctx.ts
+++ b/packages/engine/src/main/ctx.ts
@@ -44,7 +44,6 @@ export class RuntimeCtx {
         pipelinesExecuted: 0,
     };
     $stack: CtxStackFrame[] = [];
-    $stash: any = {};
     $screenshotTaken: boolean = false;
 
     constructor(action: Action) {

--- a/packages/engine/src/main/pipeline.ts
+++ b/packages/engine/src/main/pipeline.ts
@@ -155,7 +155,7 @@ export class Pipeline extends model.EntityList<Unit<any>, Pipe> {
      *  and can be passed here.
      */
     async selectAll(list: Element[], ctx: RuntimeCtx): Promise<Element[]> {
-        if (ctx.$introspectionResults) {
+        if (ctx.$introspectionEnabled) {
             ctx.$introspectionResults.push({
                 pipelineId: this.id,
                 inputSet: list,
@@ -193,7 +193,7 @@ export class Pipeline extends model.EntityList<Unit<any>, Pipe> {
                     });
                 }
             } catch (error) {
-                if (ctx.$introspectionResults) {
+                if (ctx.$introspectionEnabled) {
                     ctx.$introspectionResults.push({
                         pipeId: pipe.id,
                         inputSet: nextInputSet,


### PR DESCRIPTION
This fixes a lingering bug: workers are not supposed to collect intermediary pipeline results.

As a bonus, I've added a *developer-only* preference to disable feedback altogether, so that we can investigate memory leaks better.