### PR TITLE
fix: script search tag missing margins

### DIFF
--- a/packages/autopilot/src/app/viewports/script-flow/script-search.vue
+++ b/packages/autopilot/src/app/viewports/script-flow/script-search.vue
@@ -187,16 +187,13 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .script-search {
     position: relative;
     padding: var(--gap--small);
     background: var(--color-cool--500);
 }
 
-.script-search__criteria {
-    margin-bottom: var(--gap--small);
-}
 
 .script-search__suggestions {
     position: absolute;
@@ -221,6 +218,7 @@ export default {
 
 .script-search__criterion {
     white-space: nowrap;
+    margin: 0 var(--gap--small) var(--gap--small) 0;
 }
 
 .script-search__criterion-type {


### PR DESCRIPTION
ticket: https://ubio-automation.atlassian.net/browse/ROBO-529
script search queries don't stick together by adding margins around each tags

<img width="666" alt="Screenshot 2021-06-10 at 16 23 54" src="https://user-images.githubusercontent.com/16660866/121542504-7bc52980-ca08-11eb-9c50-bff9836b60c6.png">
